### PR TITLE
[Art] Suppermatter sprite offset

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Supermatter/supermatter.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Supermatter/supermatter.yml
@@ -66,6 +66,7 @@
     - type: Sprite
       drawdepth: WallMountedItems
       sprite: _Goobstation/Supermatter/supermatter.rsi
+      offset: 0, 0.25 # Corvax-Goob-SupermatterSpriteOffset
       state: supermatter
     - type: Icon
       sprite: _Goobstation/Supermatter/supermatter.rsi


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Добавил оффсет спрайту чтобы стояла ровно в тайле.
<img width="323" height="338" alt="image" src="https://github.com/user-attachments/assets/bb134668-0812-4f72-bfb2-d261ca6d3c7c" />
<img width="409" height="442" alt="image" src="https://github.com/user-attachments/assets/368f3e27-8515-42d9-ad0c-fc2a187ad32c" />

