### PR TITLE
[LAVALAND] Book of greentext

### DIFF
--- a/Content.Client/_CorvaxGoob/BookOfGreentext/BookOfGreentextSystem.cs
+++ b/Content.Client/_CorvaxGoob/BookOfGreentext/BookOfGreentextSystem.cs
@@ -1,0 +1,30 @@
+using Content.Shared._CorvaxGoob.BookOfGreentext;
+using Robust.Client.GameObjects;
+
+namespace Content.Client._CorvaxGoob.BookOfGreentext;
+
+public sealed class BookOfGreentextSystem : EntitySystem
+{
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CurseOfBookOfGreentextComponent, ComponentShutdown>(OnComponentShutdown);
+    }
+
+    public void OnComponentShutdown(Entity<CurseOfBookOfGreentextComponent> entity, ref ComponentShutdown ev)
+    {
+        if (TryComp<SpriteComponent>(entity, out var sprite))
+            _sprite.SetColor((entity.Owner, sprite), Color.White);
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        base.FrameUpdate(frameTime);
+
+        var query = AllEntityQuery<CurseOfBookOfGreentextComponent, SpriteComponent>();
+        while (query.MoveNext(out var uid, out var curse, out var sprite))
+            _sprite.SetColor(uid, curse.Completed ? Color.LightGreen : Color.IndianRed);
+    }
+}

--- a/Content.Server/_CorvaxGoob/BookOfGreentext/CurseOfBookOfGreentextSystem.cs
+++ b/Content.Server/_CorvaxGoob/BookOfGreentext/CurseOfBookOfGreentextSystem.cs
@@ -1,0 +1,72 @@
+using Content.Shared._CorvaxGoob.BookOfGreentext;
+using Robust.Shared.Containers;
+using Robust.Shared.Timing;
+
+namespace Content.Server._CorvaxGoob.BookOfGreentext;
+
+public sealed class CurseOfBookOfGreentextSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    private EntityQuery<ContainerManagerComponent> _containerQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _containerQuery = GetEntityQuery<ContainerManagerComponent>();
+
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var enumerator = EntityQueryEnumerator<CurseOfBookOfGreentextComponent>();
+        while (enumerator.MoveNext(out var uid, out var component))
+        {
+            if (component.NextUpdate < _timing.CurTime)
+            {
+                component.NextUpdate = _timing.CurTime + TimeSpan.FromSeconds(5);
+
+                if (!_containerQuery.TryGetComponent(uid, out var currentManager))
+                    return;
+
+                var containerStack = new Stack<ContainerManagerComponent>();
+
+                do
+                {
+                    foreach (var container in currentManager.Containers.Values)
+                    {
+                        foreach (var entity in container.ContainedEntities)
+                        {
+                            if (HasComp<BookOfGreentextComponent>(entity))
+                            {
+                                if (entity == component.Book)
+                                {
+                                    SetCurseStatus((uid, component), true);
+                                    return;
+                                }
+                            }
+
+                            // if it is a container check its contents
+                            if (_containerQuery.TryGetComponent(entity, out var containerManager))
+                                containerStack.Push(containerManager);
+                        }
+                    }
+                } while (containerStack.TryPop(out currentManager));
+
+                SetCurseStatus((uid, component), false);
+            }
+        }
+    }
+
+    private void SetCurseStatus(Entity<CurseOfBookOfGreentextComponent> entity, bool status)
+    {
+        if (entity.Comp.Completed == status)
+            return;
+
+        entity.Comp.Completed = status;
+        Dirty(entity);
+    }
+}

--- a/Content.Shared/_CorvaxGoob/BookOfGreentext/BookOfGreentextComponent.cs
+++ b/Content.Shared/_CorvaxGoob/BookOfGreentext/BookOfGreentextComponent.cs
@@ -1,0 +1,19 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CorvaxGoob.BookOfGreentext;
+
+[RegisterComponent]
+public sealed partial class BookOfGreentextComponent : Component
+{
+    /// <summary>
+    /// Delay before the book will be linked with user
+    /// </summary>
+    [DataField]
+    public TimeSpan UseDelay = TimeSpan.FromSeconds(3);
+}
+
+[Serializable, NetSerializable]
+public sealed partial class BookOfGreentextDoAfterEvent : SimpleDoAfterEvent
+{
+}

--- a/Content.Shared/_CorvaxGoob/BookOfGreentext/BookOfGreentextSystem.cs
+++ b/Content.Shared/_CorvaxGoob/BookOfGreentext/BookOfGreentextSystem.cs
@@ -1,0 +1,49 @@
+using Content.Shared.DoAfter;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Popups;
+
+namespace Content.Shared._CorvaxGoob.BookOfGreentext;
+
+public sealed class BookOfGreentextSystem : EntitySystem
+{
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BookOfGreentextComponent, UseInHandEvent>(OnUseInHand);
+        SubscribeLocalEvent<BookOfGreentextComponent, BookOfGreentextDoAfterEvent>(OnDoAfter);
+    }
+
+    private void OnUseInHand(Entity<BookOfGreentextComponent> entity, ref UseInHandEvent ev)
+    {
+        if (ev.Handled)
+            return;
+
+        if (HasComp<CurseOfBookOfGreentextComponent>(ev.User))
+        {
+            _popup.PopupClient(Loc.GetString("book-of-greentext-already-taken"), ev.User);
+            return;
+        }
+
+        _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, ev.User, entity.Comp.UseDelay, new BookOfGreentextDoAfterEvent(), entity)
+        {
+            NeedHand = true,
+            BreakOnMove = true
+        });
+    }
+
+    private void OnDoAfter(Entity<BookOfGreentextComponent> entity, ref BookOfGreentextDoAfterEvent ev)
+    {
+        if (ev.Cancelled || ev.Handled)
+            return;
+
+        EnsureComp<CurseOfBookOfGreentextComponent>(ev.User, out var curse);
+
+        curse.Book = entity;
+        _popup.PopupClient(Loc.GetString("book-of-greentext-use-message"), ev.User);
+    }
+}

--- a/Content.Shared/_CorvaxGoob/BookOfGreentext/CurseOfBookOfGreentextComponent.cs
+++ b/Content.Shared/_CorvaxGoob/BookOfGreentext/CurseOfBookOfGreentextComponent.cs
@@ -1,0 +1,25 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CorvaxGoob.BookOfGreentext;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CurseOfBookOfGreentextComponent : Component
+{
+    /// <summary>
+    /// Status of "objective".
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Completed = true;
+
+    /// <summary>
+    /// Book that linked with user.
+    /// </summary>
+    [DataField]
+    public EntityUid? Book = null;
+
+    /// <summary>
+    /// Cooldown before next check for contains the book in owner inventory.
+    /// </summary>
+    [DataField]
+    public TimeSpan NextUpdate;
+}

--- a/Content.Shared/_CorvaxGoob/BookOfGreentext/WashCurseOfGreentextReaction.cs
+++ b/Content.Shared/_CorvaxGoob/BookOfGreentext/WashCurseOfGreentextReaction.cs
@@ -1,0 +1,17 @@
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CorvaxGoob.BookOfGreentext;
+
+public sealed partial class WashCurseOfGreentextReaction : EntityEffect
+{
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => Loc.GetString("reagent-effect-guidebook-wash-curse-of-greentext-reaction", ("chance", Probability));
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        if (!args.EntityManager.TryGetComponent<CurseOfBookOfGreentextComponent>(args.TargetEntity, out var curse)) return;
+
+        args.EntityManager.RemoveComponent(args.TargetEntity, curse);
+    }
+}

--- a/Resources/Locale/ru-RU/_corvaxgoob/entities/misc/bookofgreentext.ftl
+++ b/Resources/Locale/ru-RU/_corvaxgoob/entities/misc/bookofgreentext.ftl
@@ -1,0 +1,15 @@
+book-of-greentext-already-taken = Вы уже прокляты книгой...
+book-of-greentext-use-message = Проклятие книги теперь действует на вас.. Не потеряйте её!
+
+reagent-effect-guidebook-wash-curse-of-greentext-reaction =
+    { $chance ->
+        [1] Смывает
+       *[other] смывают
+    } проклятие успеха
+
+ent-LavalandBookOfGreentext = Книга Успеха
+    .desc = Вызывает проклятие успеха. Потеря книги сделает успех невозможным.
+
+ent-LavalandCrateNecropolisBookOfGreentext = { ent-LavalandCrateNecropolis }
+    .suffix = Книга Успеха
+    .desc = { ent-LavalandCrateNecropolis.desc }

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -316,6 +316,7 @@
     - id: ClothingOuterHardsuitSalvage
     - id: ChemistryBottleOmnizine
     - id: ClothingBackpackDuffelSalvageSCAF # Corvax-Goob SCAF
+    - id: LavalandBookOfGreentext # CorvaxGoob-Lavaland-Stuff
     - id: FoodSnackLollypopWrappedCarpEvil # Goobstation
     - !type:GroupSelector
       children:

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -370,6 +370,7 @@
       methods: [Touch]
       effects:
       - !type:WashCreamPieReaction
+      - !type:WashCurseOfGreentextReaction # CorvaxGoob-Lavaland-Stuff
   - type: StatusEffects
     allowed:
     - Stun

--- a/Resources/Prototypes/_CorvaxGoob/Catalog/Fills/Crates/necropolis.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Catalog/Fills/Crates/necropolis.yml
@@ -1,0 +1,8 @@
+- type: entity
+  id: LavalandCrateNecropolisBookOfGreentext
+  parent: LavalandCrateNecropolis
+  suffix: Book Of Success
+  components:
+  - type: StorageFill
+    contents:
+      - id: LavalandBookOfGreentext

--- a/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Specific/Salvage/lavaland_loot.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Specific/Salvage/lavaland_loot.yml
@@ -1,0 +1,17 @@
+- type: entity
+  name: Book Of Success
+  parent: BaseItem
+  id: LavalandBookOfGreentext
+  description: Сauses the curse of success. Losing the book will make success impossible.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#008800"
+      map: [ "cover" ]
+    - state: decor_wingette
+      color: "#00ff00"
+      map: [ "decor" ]
+  - type: BookOfGreentext

--- a/Resources/Prototypes/_Lavaland/Entities/Markers/Spawners/Random/crates.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Markers/Spawners/Random/crates.yml
@@ -36,5 +36,6 @@
     - LavalandCrateNecropolisCultRobe
     - LavalandCrateNecropolisCultArmor
     - LavalandCrateNecropolisHeart
+    - LavalandCrateNecropolisBookOfGreentext # CorvaxGoob-Lavaland-Stuff
     - LavalandCrateNecropolisVampirismCrystal
     chance: 1


### PR DESCRIPTION
## Описание PR
В игру добавлена книга успеха (Book Of Greentext). При его использовании, пользователь окрашивается в цвет, в зависимости от нахождения книги в его инвентаре. Если она при нём - в зелёный, без неё - красный.

Данное проклятие можно снять использовав на себе воду.

Найти книгу можно некрополисе или в качестве обычного легендарного типа лута.

## Почему / Баланс
Новый предмет на лаваленд. 

Пока его можно легко достать ввиду его обычности. Вообще я планировал сделать его более сильным для пользователя. Например чтобы тот получал бафф при её ношении, и дебафф при потери, при этом проклятие снять было бы невозможно.

## Ссылка на ветку
https://discord.com/channels/919301044784226385/1407148922496880682

## Медиа

https://github.com/user-attachments/assets/87aa617c-9340-48c0-bc2b-4c09cff2ed7f

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl: KillanGenifer
- add: На лаваленд добавлен новый лут "Книга Успеха" (Book Of Greentext)
