### PR TITLE
Realistic in-game sound

### DIFF
--- a/Content.Client/_CorvaxGoob/DynamicAudio/DynamicAudioSystem.cs
+++ b/Content.Client/_CorvaxGoob/DynamicAudio/DynamicAudioSystem.cs
@@ -1,4 +1,3 @@
-using Content.Client.Atmos.Components;
 using Content.Shared._CorvaxGoob.DynamicAudio;
 using Robust.Shared.Audio.Components;
 using Robust.Shared.Audio.Systems;
@@ -21,13 +20,9 @@ public sealed class DynamicAudioSystem : EntitySystem
 
     private void OnAudioAdd(Entity<AudioComponent> ent, ref ComponentAdd args)
     {
-        if (!_playerManager.LocalEntity.HasValue)
-            return;
-
-        if (!TryComp<EyeComponent>(_playerManager.LocalEntity.Value, out var eye))
-            return;
-
-        if (!eye.DrawFov)
+        if (!_playerManager.LocalEntity.HasValue
+            || !TryComp<EyeComponent>(_playerManager.LocalEntity.Value, out var eye)
+            || !eye.DrawFov)
             return;
 
         EnsureComp<DynamicAudioComponent>(ent);
@@ -35,10 +30,10 @@ public sealed class DynamicAudioSystem : EntitySystem
 
     private void OnEffectedAudioStartup(Entity<DynamicAudioComponent> ent, ref ComponentStartup args)
     {
-        if (!TryComp<AudioComponent>(ent.Owner, out var audio))
-            return;
-
-        if (TerminatingOrDeleted(ent) || Paused(ent) || audio.Global)
+        if (!TryComp<AudioComponent>(ent.Owner, out var audio) ||
+            TerminatingOrDeleted(ent)
+            || Paused(ent)
+            || audio.Global)
             return;
 
         _dynamicAudio.ApplyAudioEffect((ent, audio));

--- a/Content.Client/_CorvaxGoob/DynamicAudio/DynamicAudioSystem.cs
+++ b/Content.Client/_CorvaxGoob/DynamicAudio/DynamicAudioSystem.cs
@@ -1,0 +1,46 @@
+using Content.Client.Atmos.Components;
+using Content.Shared._CorvaxGoob.DynamicAudio;
+using Robust.Shared.Audio.Components;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Player;
+
+namespace Content.Client._CorvaxGoob.DynamicAudio;
+
+public sealed class DynamicAudioSystem : EntitySystem
+{
+    [Dependency] private readonly SharedDynamicAudioSystem _dynamicAudio = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AudioComponent, ComponentAdd>(OnAudioAdd);
+        SubscribeLocalEvent<DynamicAudioComponent, ComponentStartup>(OnEffectedAudioStartup, after: [typeof(SharedAudioSystem)]);
+    }
+
+    private void OnAudioAdd(Entity<AudioComponent> ent, ref ComponentAdd args)
+    {
+        if (!_playerManager.LocalEntity.HasValue)
+            return;
+
+        if (!TryComp<EyeComponent>(_playerManager.LocalEntity.Value, out var eye))
+            return;
+
+        if (!eye.DrawFov)
+            return;
+
+        EnsureComp<DynamicAudioComponent>(ent);
+    }
+
+    private void OnEffectedAudioStartup(Entity<DynamicAudioComponent> ent, ref ComponentStartup args)
+    {
+        if (!TryComp<AudioComponent>(ent.Owner, out var audio))
+            return;
+
+        if (TerminatingOrDeleted(ent) || Paused(ent) || audio.Global)
+            return;
+
+        _dynamicAudio.ApplyAudioEffect((ent, audio));
+    }
+}

--- a/Content.Client/_CorvaxGoob/TTS/TTSSystem.cs
+++ b/Content.Client/_CorvaxGoob/TTS/TTSSystem.cs
@@ -1,15 +1,17 @@
-using Content.Shared.Chat;
+using Content.Client._CorvaxGoob.DynamicAudio;
+using Content.Shared._CorvaxGoob;
 using Content.Shared._CorvaxGoob.CCCVars;
+using Content.Shared._CorvaxGoob.DynamicAudio;
 using Content.Shared._CorvaxGoob.TTS;
+using Content.Shared.Chat;
 using Robust.Client.Audio;
 using Robust.Client.ResourceManagement;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
-using Robust.Shared.Utility;
-using Content.Shared._CorvaxGoob;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Client._CorvaxGoob.TTS;
 
@@ -23,6 +25,7 @@ public sealed partial class TTSSystem : EntitySystem
     [Dependency] private readonly IResourceManager _res = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly SharedDynamicAudioSystem _dynamicAudio = default!;
 
     private ISawmill _sawmill = default!;
     private static MemoryContentRoot _contentRoot = new();
@@ -92,7 +95,10 @@ public sealed partial class TTSSystem : EntitySystem
         if (ev.SourceUid != null)
         {
             var sourceUid = GetEntity(ev.SourceUid.Value);
-            _audio.PlayEntity(audioResource.AudioStream, sourceUid, soundSpecifier, audioParams);
+            var audio = _audio.PlayEntity(audioResource.AudioStream, sourceUid, soundSpecifier, audioParams);
+
+            if (audio.HasValue)
+                _dynamicAudio.ApplyAudioEffect(audio.Value, sourceUid); // applies environment effects to audio
         }
         else
         {

--- a/Content.Server/_CorvaxGoob/DynamicSound/DynamicAudioSystem.cs
+++ b/Content.Server/_CorvaxGoob/DynamicSound/DynamicAudioSystem.cs
@@ -1,9 +1,12 @@
 using Content.Server.Atmos.EntitySystems;
+using Content.Shared._CorvaxGoob.CCCVars;
 using Content.Shared._CorvaxGoob.DynamicAudio;
 using Content.Shared._CorvaxGoob.DynamicAudio.Effects;
 using Content.Shared._CorvaxGoob.TTS;
 using Robust.Shared.Audio.Components;
+using Robust.Shared.Configuration;
 using Robust.Shared.Player;
+using Robust.Shared.Timing;
 
 namespace Content.Server._CorvaxGoob.DynamicSound;
 
@@ -11,12 +14,21 @@ public sealed class DynamicAudioSystem : EntitySystem
 {
     [Dependency] private readonly AtmosphereSystem _atmos = default!;
     [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    private float _soundBarotraumaMoles = 10;
+
+    private TimeSpan _nextPlayersBarotraumaCheck = new TimeSpan();
+    private TimeSpan _cooldownPlayersCheck = TimeSpan.FromMilliseconds(100);
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<AudioComponent, MoveEvent>(OnMove);
+
+        Subs.CVar(_cfg, CCCVars.SoundBarotraumaMoles, value => _soundBarotraumaMoles = value);
     }
 
     // requires to once process sound physics like tile moles
@@ -31,13 +43,13 @@ public sealed class DynamicAudioSystem : EntitySystem
     }
 
     /// <summary>
-    /// Marks sound if it in barotrauma. Should by used instant after sound played.
+    /// Marks TTS sound if it in barotrauma. Should by used instant after sound played.
     /// </summary>
     public void DoDynamicTTSChecks(Entity<TTSComponent> entity)
     {
         var mixture = _atmos.GetTileMixture((entity, Transform(entity)));
 
-        entity.Comp.InBarotrauma = mixture is null || mixture.TotalMoles < 10;
+        entity.Comp.InBarotrauma = mixture is null || mixture.TotalMoles < _soundBarotraumaMoles;
 
         Dirty(entity);
     }
@@ -52,7 +64,7 @@ public sealed class DynamicAudioSystem : EntitySystem
 
         var mixture = _atmos.GetTileMixture((entityUid, Transform(entityUid)));
 
-        if (mixture is null || mixture.TotalMoles < 10)
+        if (mixture is null || mixture.TotalMoles < _soundBarotraumaMoles)
             Dirty(entityUid, EnsureComp<InBarotraumaAudioEffectComponent>(entityUid));
         else if (HasComp<InBarotraumaAudioEffectComponent>(entityUid))
             RemComp<InBarotraumaAudioEffectComponent>(entityUid);
@@ -61,6 +73,11 @@ public sealed class DynamicAudioSystem : EntitySystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
+
+        if (_timing.CurTime < _nextPlayersBarotraumaCheck)
+            return;
+
+        _nextPlayersBarotraumaCheck = _timing.CurTime + _cooldownPlayersCheck;
 
         foreach (var session in _playerManager.Sessions)
         {

--- a/Content.Server/_CorvaxGoob/DynamicSound/DynamicAudioSystem.cs
+++ b/Content.Server/_CorvaxGoob/DynamicSound/DynamicAudioSystem.cs
@@ -1,0 +1,73 @@
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared._CorvaxGoob.DynamicAudio;
+using Content.Shared._CorvaxGoob.DynamicAudio.Effects;
+using Content.Shared._CorvaxGoob.TTS;
+using Robust.Shared.Audio.Components;
+using Robust.Shared.Player;
+
+namespace Content.Server._CorvaxGoob.DynamicSound;
+
+public sealed class DynamicAudioSystem : EntitySystem
+{
+    [Dependency] private readonly AtmosphereSystem _atmos = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AudioComponent, MoveEvent>(OnMove);
+    }
+
+    // requires to once process sound physics like tile moles
+    private void OnMove(Entity<AudioComponent> entity, ref MoveEvent ev)
+    {
+        if (HasComp<DynamicAudioComponent>(entity))
+            return;
+
+        DoDynamicChecks(entity);
+
+        EnsureComp<DynamicAudioComponent>(entity);
+    }
+
+    /// <summary>
+    /// Marks sound if it in barotrauma. Should by used instant after sound played.
+    /// </summary>
+    public void DoDynamicTTSChecks(Entity<TTSComponent> entity)
+    {
+        var mixture = _atmos.GetTileMixture((entity, Transform(entity)));
+
+        entity.Comp.InBarotrauma = mixture is null || mixture.TotalMoles < 10;
+
+        Dirty(entity);
+    }
+
+    /// <summary>
+    /// Marks sound if it in barotrauma. Should by used instant after sound played.
+    /// </summary>
+    public void DoDynamicChecks(EntityUid entityUid)
+    {
+        if (TerminatingOrDeleted(entityUid) || Paused(entityUid))
+            return;
+
+        var mixture = _atmos.GetTileMixture((entityUid, Transform(entityUid)));
+
+        if (mixture is null || mixture.TotalMoles < 10)
+            Dirty(entityUid, EnsureComp<InBarotraumaAudioEffectComponent>(entityUid));
+        else if (HasComp<InBarotraumaAudioEffectComponent>(entityUid))
+            RemComp<InBarotraumaAudioEffectComponent>(entityUid);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        foreach (var session in _playerManager.Sessions)
+        {
+            if (session.AttachedEntity is null)
+                continue;
+
+            DoDynamicChecks(session.AttachedEntity.Value);
+        }
+    }
+}

--- a/Content.Server/_CorvaxGoob/TTS/TTSSystem.cs
+++ b/Content.Server/_CorvaxGoob/TTS/TTSSystem.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Content.Server._CorvaxGoob.DynamicSound;
 using Content.Server._EinsteinEngines.Language;
 using Content.Server.Chat.Systems;
 using Content.Server.Communications;
@@ -26,6 +27,7 @@ public sealed partial class TTSSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _rng = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly LanguageSystem _lang = default!;
+    [Dependency] private readonly DynamicAudioSystem _dynamicSound = default!;
 
     private readonly List<string> _sampleText =
         new()
@@ -116,6 +118,9 @@ public sealed partial class TTSSystem : EntitySystem
     {
         var originalSoundData = await GenerateTTS(message, speaker);
         var obfuscatedSoundData = await GenerateTTS(obfMessage, speaker);
+
+        if (TryComp<TTSComponent>(uid, out var tts))
+            _dynamicSound.DoDynamicTTSChecks((uid, tts)); // checks sound environment and applies effects if it's required
 
         foreach (var pvsSession in Filter.Pvs(uid).Recipients)
         {

--- a/Content.Shared/_CorvaxGoob/CCCVars/CCCVars.cs
+++ b/Content.Shared/_CorvaxGoob/CCCVars/CCCVars.cs
@@ -95,4 +95,10 @@ public sealed class CCCVars
     /// </summary>
     public static readonly CVarDef<bool> CalendarAnnouncerEnabled =
         CVarDef.Create("announcer.calendar", true, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Maximum count of moles in tile for barotrauma sound effect.
+    /// </summary>
+    public static readonly CVarDef<float> SoundBarotraumaMoles =
+        CVarDef.Create("sound.barotraumamoles", 10f, CVar.SERVERONLY);
 }

--- a/Content.Shared/_CorvaxGoob/DynamicAudio/DynamicAudioComponent.cs
+++ b/Content.Shared/_CorvaxGoob/DynamicAudio/DynamicAudioComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CorvaxGoob.DynamicAudio;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class DynamicAudioComponent : Component
+{
+
+}

--- a/Content.Shared/_CorvaxGoob/DynamicAudio/Effects/InBarotraumaAudioEffectComponent.cs
+++ b/Content.Shared/_CorvaxGoob/DynamicAudio/Effects/InBarotraumaAudioEffectComponent.cs
@@ -3,6 +3,4 @@ using Robust.Shared.GameStates;
 namespace Content.Shared._CorvaxGoob.DynamicAudio.Effects;
 
 [RegisterComponent, NetworkedComponent]
-public sealed partial class InBarotraumaAudioEffectComponent : Component
-{
-}
+public sealed partial class InBarotraumaAudioEffectComponent : Component;

--- a/Content.Shared/_CorvaxGoob/DynamicAudio/Effects/InBarotraumaAudioEffectComponent.cs
+++ b/Content.Shared/_CorvaxGoob/DynamicAudio/Effects/InBarotraumaAudioEffectComponent.cs
@@ -1,0 +1,8 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CorvaxGoob.DynamicAudio.Effects;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class InBarotraumaAudioEffectComponent : Component
+{
+}

--- a/Content.Shared/_CorvaxGoob/DynamicAudio/SharedDynamicAudioSystem.cs
+++ b/Content.Shared/_CorvaxGoob/DynamicAudio/SharedDynamicAudioSystem.cs
@@ -39,6 +39,8 @@ public sealed class SharedDynamicAudioSystem : EntitySystem
     private int _maxAreaScanRadius = 8; // prefer to set value of pvs divided by 2
     private int _maxTilesScanCount = 200;
 
+    private int _soundMuffleInSpace = -10;
+
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly INetManager _net = default!;
@@ -91,7 +93,7 @@ public sealed class SharedDynamicAudioSystem : EntitySystem
         if (TryComp<TTSComponent>(source, out var ttsComp) && ttsComp.InBarotrauma || soundTransform.GridUid is null || HasComp<InBarotraumaAudioEffectComponent>(soundTransform.Owner)
             || _playerManager.LocalEntity.HasValue && HasComp<InBarotraumaAudioEffectComponent>(_playerManager.LocalEntity))
         {
-            _audio.SetVolume(audio, -10);
+            _audio.SetVolume(audio, _soundMuffleInSpace);
             return _inSpacePreset;
         }
 

--- a/Content.Shared/_CorvaxGoob/DynamicAudio/SharedDynamicAudioSystem.cs
+++ b/Content.Shared/_CorvaxGoob/DynamicAudio/SharedDynamicAudioSystem.cs
@@ -1,0 +1,207 @@
+using Content.Shared._CorvaxGoob.DynamicAudio.Effects;
+using Content.Shared._CorvaxGoob.TTS;
+using Content.Shared.GameTicking;
+using Content.Shared.Maps;
+using Content.Shared.Parallax.Biomes;
+using Content.Shared.Physics;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Components;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Network;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+
+namespace Content.Shared._CorvaxGoob.DynamicAudio;
+
+public sealed class SharedDynamicAudioSystem : EntitySystem
+{
+    private Dictionary<ProtoId<AudioPresetPrototype>, EntityUid> _presets = new();
+    private Dictionary<int, string> _areaPresets = new Dictionary<int, string> // sort it or will be broken
+    {
+        { 10, "Underwater" },
+        { 30, "Bathroom" },
+        { 70, "SpaceStationSmallRoom" },
+        { 120, "SpaceStationMediumRoom" },
+        { 150, "SpaceStationLargeRoom" },
+        { 200, "SpaceStationHall" }
+    };
+
+    private string _defaultPreset = "LivingRoom";
+    private string _inSpacePreset = "InSpace";
+    private string _onPlanetPreset = "Forest";
+
+    private int _maxAreaScanRadius = 8; // prefer to set value of pvs divided by 2
+    private int _maxTilesScanCount = 200;
+
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedTransformSystem _xform = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
+    [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly EntityLookupSystem _lookUp = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(_ => _presets.Clear());
+    }
+
+    /// <summary>
+    /// Applies sound effects by it's environment.
+    /// </summary>
+    public void ApplyAudioEffect(Entity<AudioComponent> audio, EntityUid? source = null)
+    {
+        if (!_playerManager.LocalEntity.HasValue)
+            return;
+
+        var preset = GetAreaPrototypePreset(audio, source);
+
+        if (!_presets.TryGetValue(preset, out var audioAux) && !TryCreateAudioEffect(preset, out audioAux))
+            return;
+
+        if (_net.IsServer)
+            Timer.Spawn(TimeSpan.FromTicks(10L), () => _audio.SetAuxiliary(audio, audio, audioAux));
+        else
+            _audio.SetAuxiliary(audio, audio, audioAux);
+    }
+
+    /// <summary>
+    /// Calculates sound area by it's effects components, local player position etc.
+    /// </summary>
+    private string GetAreaPrototypePreset(Entity<AudioComponent> audio, EntityUid? source = null)
+    {
+        var soundPosition = source is null ? _xform.GetWorldPosition(audio) : _xform.GetWorldPosition(source.Value);
+        var soundTransform = source is null ? Transform(audio) : Transform(source.Value);
+
+        if (soundPosition == Vector2.Zero && _playerManager.LocalEntity.HasValue)
+        {
+            soundPosition = _xform.GetWorldPosition(_playerManager.LocalEntity.Value);
+            soundTransform = Transform(_playerManager.LocalEntity.Value);
+        }
+
+        // checks if sound or player in space
+        if (TryComp<TTSComponent>(source, out var ttsComp) && ttsComp.InBarotrauma || soundTransform.GridUid is null || HasComp<InBarotraumaAudioEffectComponent>(soundTransform.Owner)
+            || _playerManager.LocalEntity.HasValue && HasComp<InBarotraumaAudioEffectComponent>(_playerManager.LocalEntity))
+        {
+            _audio.SetVolume(audio, -10);
+            return _inSpacePreset;
+        }
+
+        // checks if sound on planet
+        if (HasComp<BiomeComponent>(soundTransform.GridUid))
+            return _onPlanetPreset;
+
+        if (!TryComp<MapGridComponent>(soundTransform.GridUid, out var mapGrid))
+            return _defaultPreset;
+
+        int estimatedArea = CountTilesInRoom(_map.TileIndicesFor(soundTransform.GridUid.Value, mapGrid, _xform.GetMapCoordinates(soundTransform)), (soundTransform.GridUid.Value, mapGrid));
+
+        foreach (var areaPreset in _areaPresets)
+            if (estimatedArea <= areaPreset.Key)
+                return areaPreset.Value;
+
+        return _defaultPreset;
+    }
+
+    /// <summary>
+    /// Calculates room area tile by tile.
+    /// </summary>
+    private int CountTilesInRoom(Vector2i startTile, Entity<MapGridComponent> grid)
+    {
+        var visited = new HashSet<Vector2i>();
+        var queue = new Queue<Vector2i>();
+
+        queue.Enqueue(startTile);
+        visited.Add(startTile);
+
+        var directions = new Vector2i[] { new(0, 1), new(1, 0), new(0, -1), new(-1, 0) };
+
+        while (queue.Count > 0)
+        {
+            var currentTile = queue.Dequeue();
+
+            var distance = Math.Abs(currentTile.X - startTile.X) +
+                          Math.Abs(currentTile.Y - startTile.Y);
+
+            if (distance > _maxAreaScanRadius) // must be restricted by radius or your CPU gets fuck
+                continue;
+
+            if (visited.Count > _maxTilesScanCount) // and also by maximum of tiles
+                break;
+
+            foreach (var direction in directions)
+            {
+                var neighborTile = currentTile + direction;
+
+                if (visited.Contains(neighborTile))
+                    continue;
+
+                if (IsValidTile(neighborTile, grid))
+                {
+                    visited.Add(neighborTile);
+                    queue.Enqueue(neighborTile);
+                }
+            }
+        }
+
+        return visited.Count;
+    }
+
+    /// <summary>
+    /// Validates tile for being space or solid structure in it like wall that can block sound.
+    /// </summary>
+    private bool IsValidTile(Vector2i tilePos, Entity<MapGridComponent> grid)
+    {
+        if (!_map.TryGetTileRef(grid.Owner, grid.Comp, tilePos, out var tile))
+            return false;
+
+        if (tile.IsSpace())
+            return false;
+
+        var loc = _map.GridTileToWorld(grid.Owner, grid.Comp, tilePos);
+        foreach (var ent in _lookUp.GetEntitiesInRange(loc, 0.01f))
+            if (TryComp<PhysicsComponent>(ent, out var phys) &&
+                phys.BodyType == BodyType.Static &&
+                phys.Hard &&
+                (phys.CollisionLayer & (int) (CollisionGroup.Impassable | CollisionGroup.HighImpassable)) != 0)
+            {
+                return false;
+            }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Tries to get effect from dictionary or create and save it.
+    /// </summary>
+    private bool TryCreateAudioEffect(ProtoId<AudioPresetPrototype> preset, [NotNullWhen(true)] out EntityUid auxUid)
+    {
+        auxUid = default;
+
+        if (!_prototype.TryIndex<AudioPresetPrototype>(preset, out var presetPrototype))
+            return false;
+
+        var effectEntity = _audio.CreateEffect();
+        var auxEntity = _audio.CreateAuxiliary();
+
+        _audio.SetEffectPreset(effectEntity.Entity, effectEntity.Component, presetPrototype);
+        _audio.SetEffect(auxEntity.Entity, auxEntity.Component, effectEntity.Entity);
+
+        if (Exists(auxEntity.Entity))
+        {
+            auxUid = auxEntity.Entity;
+            _presets.Add(preset, auxUid);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Content.Shared/_CorvaxGoob/TTS/TTSComponent.cs
+++ b/Content.Shared/_CorvaxGoob/TTS/TTSComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared._CorvaxGoob.TTS;
 /// <summary>
 /// Apply TTS for entity chat say messages
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 // ReSharper disable once InconsistentNaming
 public sealed partial class TTSComponent : Component
 {
@@ -14,6 +14,13 @@ public sealed partial class TTSComponent : Component
     /// Prototype of used voice for TTS.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("voice", customTypeSerializer: typeof(PrototypeIdSerializer<TTSVoicePrototype>))]
+    [DataField("voice", serverOnly: true, customTypeSerializer: typeof(PrototypeIdSerializer<TTSVoicePrototype>))]
     public string? VoicePrototypeId { get; set; }
+
+    /// <summary>
+    /// Tells to client dynamic audio system that TTS source in barotrauma. Don't ask me why please.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField, AutoNetworkedField]
+    public bool InBarotrauma { get; set; } = false;
 }

--- a/Resources/Prototypes/_CorvaxGoob/audio_presets.yml
+++ b/Resources/Prototypes/_CorvaxGoob/audio_presets.yml
@@ -45,7 +45,7 @@
   modulationTime: 1.1800
   modulationDepth: 0.9480
   airAbsorptionGainHf: 0.9900
-  hfReference: 3500.0000
+  hfReference: 500.0000
   lfReference: 250.0000
   roomRolloffFactor: 0.0000
   decayHfLimit: 0

--- a/Resources/Prototypes/_CorvaxGoob/audio_presets.yml
+++ b/Resources/Prototypes/_CorvaxGoob/audio_presets.yml
@@ -23,3 +23,29 @@
   lfReference: 458.2000
   roomRolloffFactor: 0.0000
   decayHfLimit: 1
+
+- type: audioPreset
+  id: InSpace
+  density: 0.3645
+  diffusion: 1.0000
+  gain: 0.3162
+  gainHf: 1.00000
+  gainLf: 1.0000
+  decayTime: 2.0000
+  decayHfRatio: 0.1000
+  decayLfRatio: 1.0000
+  reflectionsGain: 0.1000
+  reflectionsDelay: 0.0070
+  reflectionsPan: 0,0,0
+  lateReverbGain: 9.0795
+  lateReverbDelay: 0.0110
+  lateReverbPan: 0,0,0
+  echoTime: 0.2500
+  echoDepth: 0.0000
+  modulationTime: 1.1800
+  modulationDepth: 0.9480
+  airAbsorptionGainHf: 0.9900
+  hfReference: 3500.0000
+  lfReference: 250.0000
+  roomRolloffFactor: 0.0000
+  decayHfLimit: 0


### PR DESCRIPTION
## Описание PR
Был добавлен реалистичный звук в зависимости от его окружения.

## Технические детали
Ухх, ну это пиздец на самом деле.

Чтобы применить эффект для звука, требуется где-то поймать его спавн. Получилось это сделать на этапе добавления компонента `Audio`, где звуку добавился компач `DynamicSound`, который уже после при своей инициализации и подгрузки системы звука, запускает функцию просчёта пространства вокруг себя. 

Господи, не спрашивайте почему так, я двое суток ебался с этим.

```csharp
    public override void Initialize()
    {
        base.Initialize();

        SubscribeLocalEvent<AudioComponent, ComponentAdd>(OnAudioAdd);
        SubscribeLocalEvent<DynamicAudioComponent, ComponentStartup>(OnEffectedAudioStartup, after: [typeof(SharedAudioSystem)]);
    }

    private void OnAudioAdd(Entity<AudioComponent> ent, ref ComponentAdd args)
    {
        if (!_playerManager.LocalEntity.HasValue)
            return;

        if (!TryComp<EyeComponent>(_playerManager.LocalEntity.Value, out var eye))
            return;

        if (!eye.DrawFov)
            return;

        EnsureComp<DynamicAudioComponent>(ent);
    }

    private void OnEffectedAudioStartup(Entity<DynamicAudioComponent> ent, ref ComponentStartup args)
    {
        if (!TryComp<AudioComponent>(ent.Owner, out var audio))
            return;

        if (TerminatingOrDeleted(ent) || Paused(ent) || audio.Global)
            return;

        _dynamicAudio.ApplyAudioEffect((ent, audio));
    }
```

### Просчёт окружения

При просчёте, код пытается опредилить и указать в данных просчёта перед ним: клиентский, серверный, либо клиентский с указанием источника звука. И в зависимости от типа, финальный результат может сильно отличаться.
```csharp
private string GetAreaPrototypePreset(Entity<AudioComponent> audio, EntityUid? source = null)
    {
        var soundPosition = source is null ? _xform.GetWorldPosition(audio) : _xform.GetWorldPosition(source.Value);
        var soundTransform = source is null ? Transform(audio) : Transform(source.Value);

        if (soundPosition == Vector2.Zero && _playerManager.LocalEntity.HasValue)
        {
            soundPosition = _xform.GetWorldPosition(_playerManager.LocalEntity.Value);
            soundTransform = Transform(_playerManager.LocalEntity.Value);
        }
...
```
После идут основные просчёты: находится ли звук на планете, в космосе, если да, то играет ли ТТС и от кого. Если эти условия не прошли, значит запускается просчёт размера помещения по количеству тайлов. Алгоритм достаточно простой. С первичного тайла мы просчитаем соседние, вычисляем, являются ли они космосом или заняты большим объектом по типу стены, с соседних соседние, если повторяются - скипаем. И так, пока либо лимиты в ввиде ограничения для PvS'а, либо по количеству не откажут, либо все тайлы не будут просчитаны.

```csharp
    /// <summary>
    /// Calculates room area tile by tile.
    /// </summary>
    private int CountTilesInRoom(Vector2i startTile, Entity<MapGridComponent> grid)
    {
        var visited = new HashSet<Vector2i>();
        var queue = new Queue<Vector2i>();

        queue.Enqueue(startTile);
        visited.Add(startTile);

        var directions = new Vector2i[] { new(0, 1), new(1, 0), new(0, -1), new(-1, 0) };

        while (queue.Count > 0)
        {
            var currentTile = queue.Dequeue();

            var distance = Math.Abs(currentTile.X - startTile.X) +
                          Math.Abs(currentTile.Y - startTile.Y);

            if (distance > _maxAreaScanRadius) // must be restricted by radius or your CPU gets fuck
                continue;

            if (visited.Count > _maxTilesScanCount) // and also by maximum of tiles
                break;

            foreach (var direction in directions)
            {
                var neighborTile = currentTile + direction;

                if (visited.Contains(neighborTile))
                    continue;

                if (IsValidTile(neighborTile, grid))
                {
                    visited.Add(neighborTile);
                    queue.Enqueue(neighborTile);
                }
            }
        }

        return visited.Count;
    }
```

```csharp
    /// <summary>
    /// Validates tile for being space or solid structure in it like wall that can block sound.
    /// </summary>
    private bool IsValidTile(Vector2i tilePos, Entity<MapGridComponent> grid)
    {
        if (!_map.TryGetTileRef(grid.Owner, grid.Comp, tilePos, out var tile))
            return false;

        if (tile.IsSpace())
            return false;

        var loc = _map.GridTileToWorld(grid.Owner, grid.Comp, tilePos);
        foreach (var ent in _lookUp.GetEntitiesInRange(loc, 0.01f))
            if (TryComp<PhysicsComponent>(ent, out var phys) &&
                phys.BodyType == BodyType.Static &&
                phys.Hard &&
                (phys.CollisionLayer & (int) (CollisionGroup.Impassable | CollisionGroup.HighImpassable)) != 0)
            {
                return false;
            }

        return true;
    }
```
Как только мы получили количество тайлов в помещении, мы прогоняем его через словарь, в поисках подходящего эффекта под помещение. По дефолту словарь выглядит так (числа - колво тайлов):

```csharp
    private Dictionary<int, string> _areaPresets = new Dictionary<int, string> // sort it or will be broken
    {
        { 10, "Underwater" },
        { 30, "Bathroom" },
        { 70, "SpaceStationSmallRoom" },
        { 120, "SpaceStationMediumRoom" },
        { 150, "SpaceStationLargeRoom" },
        { 200, "SpaceStationHall" }
    };
```

```csharp
        foreach (var areaPreset in _areaPresets)
            if (estimatedArea <= areaPreset.Key)
                return areaPreset.Value;
```

И уже из после полученного присета мы обращаемся к другой функции, которая работает по принципу "Найди эффект в списке, либо создай и вставь". Тут уже нужно ударяться в работу применения эффектов в движке, но если говорить просто, то на основе присета, создаётся слот-эффект (`Auxiliary`), уже после который применяется на звук в движке для ревербрации звука `EAX`.

### Как игра понимает, находится ли звук в космосе.

ахахах ну тут тоже пиздец. Игра не отправляет клиенту информацию о газах в тайлах, всё это обрабатывается на сервере. Поэтому я долгое время гадал, а кака так сделать шоб было. И я придумал отличнейшее решение (нет). 
Оказывается, если применять новые компоненты до отправки на клиент, то они успевают применяться до того, как будут отправлены движком. И вот таким костылём, я создал компонент-эффект `InBarotraumaAudioEffectComponent`, который накладывается на звук перед отправкой, а уже после клиент видит, что это звук находится в космосе и применяет на него данный эффект.

`Content.Server`
```csharp
    /// <summary>
    /// Marks sound if it in barotrauma. Should by used instant after sound played.
    /// </summary>
    public void DoDynamicChecks(EntityUid entityUid)
    {
        if (TerminatingOrDeleted(entityUid) || Paused(entityUid))
            return;

        var mixture = _atmos.GetTileMixture((entityUid, Transform(entityUid)));

        if (mixture is null || mixture.TotalMoles < 10)
            Dirty(entityUid, EnsureComp<InBarotraumaAudioEffectComponent>(entityUid));
        else if (HasComp<InBarotraumaAudioEffectComponent>(entityUid))
            RemComp<InBarotraumaAudioEffectComponent>(entityUid);
    }
```

С ТТСом обстоит примерно такая же ситуация. Из-за слегда забавной системы, что звук ТТСа проигрывается клиентом, а не сервером, клиент не может знать от сервера, находится ли он в космосе. Поэтому Компачу ТТСа я добавил новый параметр, который и помечает ТТС как в космосе :D

```csharp
    /// <summary>
    /// Marks sound if it in barotrauma. Should by used instant after sound played.
    /// </summary>
    public void DoDynamicTTSChecks(Entity<TTSComponent> entity)
    {
        var mixture = _atmos.GetTileMixture((entity, Transform(entity)));

        entity.Comp.InBarotrauma = mixture is null || mixture.TotalMoles < 10;

        Dirty(entity);
    }
```

### Заключение

Кароче, мальчики и девочки. Если вы хотите создать систему реалистичных звуков как тут - лучше пиздуйте к оффам и просите переделать звуки и их эффекты в движке, чтобы не пришлось костыльно работать как я.

## Медиа

Звук после ПРа:

https://github.com/user-attachments/assets/37dcee2e-669a-4c31-973b-fec0f722ae20

Звук до ПРа:

https://github.com/user-attachments/assets/44f0f0c9-364f-4c98-828e-1b624e20858b

Звук в очень малых помещениях (10< тайлов):

https://github.com/user-attachments/assets/88e2b2d0-2efc-49a3-a47a-031fee63c25c

Звук в малых помещениях (>30 тайлов)

https://github.com/user-attachments/assets/51e94e6e-592f-4c37-824b-8ef01a0c6371

Звук в средних помещениях (>70 тайлов)

https://github.com/user-attachments/assets/3231435d-9811-451f-9e18-aa27c8af1af7

Звук в больших помещениях (>120 тайлов)

https://github.com/user-attachments/assets/8daad45a-7407-44d7-bd19-e6fea256feaa

(Ещё есть очень больших помещениях >200 тайлов, но футажа нету, представьте что там ебейшее эхо)

Звук в космосе

https://github.com/user-attachments/assets/0b5474a8-28db-4598-bc0f-ff8972fdc84d

Эффект звука при разгерме. Применяется если в тайле меньше 10 молей газа.

https://github.com/user-attachments/assets/0146c43a-be41-4747-8463-55b7aadff272

Звук на планетах

https://github.com/user-attachments/assets/7272c842-99b5-48cc-b1b2-5b964ae697b2

**Список изменений**
:cl: KillanGenifer
- add: Добавлен реалистиный звук, зависимый от его окружения.