### PR TITLE
aghost eye slot

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
@@ -91,13 +91,3 @@
       uiWindowPos: 0,1
       strippingWindowPos: 1,1
       displayName: Mask
-
-    # Corvax aghost-MLG start
-    - name: eyes
-      slotTexture: glasses
-      slotFlags: EYES
-      stripTime: 3
-      uiWindowPos: 0,3
-      strippingWindowPos: 0,0
-      displayName: Eyes
-    # Corvax aghost-MLG end


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Апстрим фичи с [ванилы](https://github.com/space-syndicate/space-station-14/pull/3384)
~~Возвращена команда `togglehealthoverlay`.~~ Aгхостам добавлен слот для визоров.

## Почему / Баланс
Потому что (и по воле @KillanGenifer ([пруф](https://discord.com/channels/919301044784226385/1412256210031345836)))
Теперь и по воле @Dimmon1.

## Технические детали
Изменён прототип, сегодня без техники.

## Медиа
<img width="1244" height="624" alt="image" src="https://github.com/user-attachments/assets/c5b91420-3cb9-4318-8f4a-77442adedf78" />


## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Критические изменения
Отсутствуют

## Список изменений
:cl:
- add: Aгхостам добавлен слот для визоров.

