### PR TITLE
Шейдеринг + команда для установки цвета

### DIFF
--- a/Content.Client/_CorvaxGoob/ColorVisuals/ColorVisualsSystem.cs
+++ b/Content.Client/_CorvaxGoob/ColorVisuals/ColorVisualsSystem.cs
@@ -1,0 +1,31 @@
+using Content.Shared._CorvaxGoob.ColorVisuals;
+using Robust.Client.GameObjects;
+
+namespace Content.Client._CorvaxGoob.ColorVisuals;
+
+public sealed class ColorVisualsSystem : EntitySystem
+{
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ColorVisualsComponent, AppearanceChangeEvent>(OnChangeData);
+        SubscribeLocalEvent<ColorVisualsComponent, ComponentShutdown>(OnComponentShutdown);
+    }
+
+    private void OnChangeData(Entity<ColorVisualsComponent> entity, ref AppearanceChangeEvent args)
+    {
+        if (!args.AppearanceData.TryGetValue(Shared._CorvaxGoob.ColorVisuals.ColorVisuals.Color, out var color) ||
+            args.Sprite == null) return;
+
+        _sprite.SetColor((entity.Owner, args.Sprite), (Color) color);
+    }
+
+    private void OnComponentShutdown(Entity<ColorVisualsComponent> entity, ref ComponentShutdown args)
+    {
+        if (TryComp<SpriteComponent>(entity, out var sprite))
+            _sprite.SetColor((entity.Owner, sprite), Color.White);
+    }
+}

--- a/Content.Client/_CorvaxGoob/CustomShader/CustomShaderSystem.cs
+++ b/Content.Client/_CorvaxGoob/CustomShader/CustomShaderSystem.cs
@@ -1,0 +1,72 @@
+using Content.Client.Crayon;
+using Content.Goobstation.Shared.Enchanting.Components;
+using Content.Shared._CorvaxGoob.CustomShader;
+using Content.Shared.Crayon;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._CorvaxGoob.CustomShader;
+
+public sealed class CustomShaderSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly ILogManager _logManager = default!;
+
+    private ISawmill _sawmill = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CustomShaderComponent, ComponentInit>(OnComponentInit);
+        SubscribeLocalEvent<CustomShaderComponent, ComponentShutdown>(OnComponentShutdown);
+
+        SubscribeLocalEvent<CustomShaderComponent, AfterAutoHandleStateEvent>(OnHandleState);
+
+        _sawmill = _logManager.GetSawmill("customshader");
+    }
+
+    private void OnHandleState(Entity<CustomShaderComponent> entity, ref AfterAutoHandleStateEvent args)
+    {
+        if (entity.Comp.Shader is null)
+            return;
+
+        ApplyShader(entity, entity.Comp.Shader);
+    }
+
+    private void OnComponentInit(Entity<CustomShaderComponent> entity, ref ComponentInit ev)
+    {
+        if (entity.Comp.Shader is null)
+            return;
+
+        ApplyShader(entity, entity.Comp.Shader);
+    }
+
+    private void OnComponentShutdown(Entity<CustomShaderComponent> entity, ref ComponentShutdown ev)
+    {
+        if (entity.Comp.Shader is null)
+            return;
+
+        ClearShader(entity);
+    }
+
+    private void ApplyShader(EntityUid entity, string shaderId)
+    {
+        if (!_prototype.TryIndex<ShaderPrototype>(shaderId, out var shaderPrototype))
+        {
+            _sawmill.Error("Invalid custom shader prototype id " + shaderId);
+            return;
+        }
+
+        if (TryComp<SpriteComponent>(entity, out var sprite))
+            sprite.PostShader = shaderPrototype.InstanceUnique();
+    }
+
+    private void ClearShader(EntityUid entity)
+    {
+        if (TryComp<SpriteComponent>(entity, out var sprite))
+            sprite.PostShader = null;
+    }
+}

--- a/Content.Server/_CorvaxGoob/Toolshed/Commands/Misc/ColorCommand.cs
+++ b/Content.Server/_CorvaxGoob/Toolshed/Commands/Misc/ColorCommand.cs
@@ -1,0 +1,41 @@
+using Content.Server.Administration;
+using Content.Shared._CorvaxGoob.ColorVisuals;
+using Content.Shared.Administration;
+using Robust.Server.GameObjects;
+using Robust.Shared.Toolshed;
+
+namespace Content.Server._CorvaxGoob.Toolshed.Commands.Misc;
+
+/// <summary>
+/// Изменяет цвет спрайта.
+/// </summary>
+[ToolshedCommand, AdminCommand(AdminFlags.VarEdit)]
+public sealed class ColorCommand : ToolshedCommand
+{
+    private AppearanceSystem? _appearance;
+
+    [CommandImplementation("set")]
+    public IEnumerable<EntityUid> Set([PipedArgument] IEnumerable<EntityUid> input, string color)
+    {
+        _appearance ??= GetSys<AppearanceSystem>();
+
+        foreach (var ent in input)
+        {
+            EnsureComp<ColorVisualsComponent>(ent);
+            _appearance.SetData(ent, ColorVisuals.Color, Color.FromHex(color));
+            yield return ent;
+        }
+    }
+
+    [CommandImplementation("clear")]
+    public IEnumerable<EntityUid> Clear([PipedArgument] IEnumerable<EntityUid> input)
+    {
+        _appearance ??= GetSys<AppearanceSystem>();
+
+        foreach (var ent in input)
+        {
+            RemComp<ColorVisualsComponent>(ent);
+            yield return ent;
+        }
+    }
+}

--- a/Content.Shared/_CorvaxGoob/ColorVisuals/ColorVisualsComponent.cs
+++ b/Content.Shared/_CorvaxGoob/ColorVisuals/ColorVisualsComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CorvaxGoob.ColorVisuals;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ColorVisualsComponent : Component;
+
+
+[Serializable, NetSerializable]
+public enum ColorVisuals : byte
+{
+    Color,
+}

--- a/Content.Shared/_CorvaxGoob/CustomShader/CustomShaderComponent.cs
+++ b/Content.Shared/_CorvaxGoob/CustomShader/CustomShaderComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CorvaxGoob.CustomShader;
+
+/// <summary>
+/// Применяет указанный в нём шейдер на сущность.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
+public sealed partial class CustomShaderComponent : Component
+{
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public string? Shader { get; set; }
+}

--- a/Resources/Locale/ru-RU/_CorvaxGoob/commands/toolshed-commands.ftl
+++ b/Resources/Locale/ru-RU/_CorvaxGoob/commands/toolshed-commands.ftl
@@ -1,0 +1,2 @@
+command-description-color-set = Изменяет цвет спрайта сущности.
+command-description-color-clear = Сбрасывает установленный цвет спрайта сущности.


### PR DESCRIPTION
## Описание PR
Добавлен компонент `CustomShaderComponent`, который позволяет на лету ставить любым сущностям прототип шейдера, что также позволяет загружать собственные шейдеры и модифицировать визуал сущности как душе угодно.

Добавлена тулшед-команда `color:set/clear`. Позволяет админам менять цвет сущности по HEX и сбрасывать его соотвественно

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl: KillanGenifer
- add: Добавлен компонент `CustomShaderComponent`, который позволяет на лету ставить любым сущностям прототип шейдера.
- add: Добавлена тулшед-команда `color:set/clear`. Позволяет админам менять цвет сущности по HEX и сбрасывать его соотвественно.