### PR TITLE
Add configurable implant and channel for CrewMonitorScanning

### DIFF
--- a/Content.Goobstation.Server/CrewMonitoring/CrewMonitorScanningSystem.cs
+++ b/Content.Goobstation.Server/CrewMonitoring/CrewMonitorScanningSystem.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
+// SPDX-FileCopyrightText: 2026 termertop1gg <pasdnikov777@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -26,7 +27,6 @@ public sealed class CrewMonitorScanningSystem : EntitySystem
     [Dependency] private readonly SharedSubdermalImplantSystem _implantSystem = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
 
-    private const string CommandTrackerImplant = "CommandTrackingImplant";
     private const string CommandTrackerImplantName = "command tracking implant";
 
     public override void Initialize()
@@ -71,7 +71,7 @@ public sealed class CrewMonitorScanningSystem : EntitySystem
         }
 
         comp.ScannedEntities.Add(args.Target.Value); //Keep for don't double implant
-        _implantSystem.AddImplant(args.Target.Value, CommandTrackerImplant);
+        _implantSystem.AddImplant(args.Target.Value, comp.Implant);
 
         if (comp.ApplyDeathrattle)
             EnsureComp<RelayedDeathrattleComponent>(args.Target.Value).Target = uid;

--- a/Content.Goobstation.Server/CrewMonitoring/CrewMonitorScanningSystem.cs
+++ b/Content.Goobstation.Server/CrewMonitoring/CrewMonitorScanningSystem.cs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
-// SPDX-FileCopyrightText: 2026 termertop1gg <pasdnikov777@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -71,7 +70,7 @@ public sealed class CrewMonitorScanningSystem : EntitySystem
         }
 
         comp.ScannedEntities.Add(args.Target.Value); //Keep for don't double implant
-        _implantSystem.AddImplant(args.Target.Value, comp.Implant);
+        _implantSystem.AddImplant(args.Target.Value, comp.Implant); // CorvaxGoob
 
         if (comp.ApplyDeathrattle)
             EnsureComp<RelayedDeathrattleComponent>(args.Target.Value).Target = uid;

--- a/Content.Goobstation.Shared/CrewMonitoring/CrewMonitorScanningComponent.cs
+++ b/Content.Goobstation.Shared/CrewMonitoring/CrewMonitorScanningComponent.cs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
-// SPDX-FileCopyrightText: 2026 termertop1gg <pasdnikov777@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -26,6 +25,7 @@ public sealed partial class CrewMonitorScanningComponent : Component
     [DataField]
     public EntityWhitelist Whitelist = new ();
 
+    // CorvaxGoob — start
     /// <summary>
     ///     The implant prototype to inject into scanned targets.
     ///     Defaults to the command tracking implant used by the BSO crew monitor.
@@ -41,4 +41,5 @@ public sealed partial class CrewMonitorScanningComponent : Component
     /// </summary>
     [DataField]
     public string? TrackerChannel;
+    // CorvaxGoob — end
 }

--- a/Content.Goobstation.Shared/CrewMonitoring/CrewMonitorScanningComponent.cs
+++ b/Content.Goobstation.Shared/CrewMonitoring/CrewMonitorScanningComponent.cs
@@ -2,10 +2,12 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
+// SPDX-FileCopyrightText: 2026 termertop1gg <pasdnikov777@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Shared.Whitelist;
+using Robust.Shared.Prototypes;
 
 namespace Content.Goobstation.Shared.CrewMonitoring;
 
@@ -23,4 +25,20 @@ public sealed partial class CrewMonitorScanningComponent : Component
 
     [DataField]
     public EntityWhitelist Whitelist = new ();
+
+    /// <summary>
+    ///     The implant prototype to inject into scanned targets.
+    ///     Defaults to the command tracking implant used by the BSO crew monitor.
+    /// </summary>
+    [DataField]
+    public EntProtoId Implant = "CommandTrackingImplant";
+
+    /// <summary>
+    ///     Optional channel identifier. When set, the attached
+    ///     <see cref="Content.Server.Medical.CrewMonitoring.CrewMonitoringConsoleComponent"/> will only display
+    ///     sensors whose <see cref="Content.Shared.Medical.SuitSensor.SuitSensorStatus.TrackerChannel"/> matches this value.
+    ///     Null keeps the legacy behaviour (filter by <c>IsCommandTracker</c>).
+    /// </summary>
+    [DataField]
+    public string? TrackerChannel;
 }

--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
@@ -102,7 +102,7 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
                 ? pair.Value.TrackerChannel == channel
                 : isCommandOnly
                     ? pair.Value.IsCommandTracker
-                    : !pair.Value.IsCommandTracker)
+                    : !pair.Value.IsCommandTracker && pair.Value.TrackerChannel == null)
             .Select(pair => pair.Value)
             .ToList();
         _uiSystem.SetUiState(uid, CrewMonitoringUIKey.Key, new CrewMonitoringState(filteredSensors));

--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
@@ -15,7 +15,6 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
-// SPDX-FileCopyrightText: 2026 termertop1gg <pasdnikov777@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -93,6 +92,7 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
 
         // Update all sensors info
         // GoobStation - Start
+        // CorvaxGoob — start
         TryComp<CrewMonitorScanningComponent>(uid, out var scanning);
         var isCommandOnly = scanning != null;
         var channel = scanning?.TrackerChannel;
@@ -105,6 +105,7 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
                     : !pair.Value.IsCommandTracker && pair.Value.TrackerChannel == null)
             .Select(pair => pair.Value)
             .ToList();
+        // CorvaxGoob — end
         _uiSystem.SetUiState(uid, CrewMonitoringUIKey.Key, new CrewMonitoringState(filteredSensors));
         // GoobStation - End
         //var allSensors = component.ConnectedSensors.Values.ToList();

--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
@@ -15,6 +15,7 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
+// SPDX-FileCopyrightText: 2026 termertop1gg <pasdnikov777@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -92,12 +93,16 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
 
         // Update all sensors info
         // GoobStation - Start
-        var isCommandOnly = HasComp<CrewMonitorScanningComponent>(uid);
+        TryComp<CrewMonitorScanningComponent>(uid, out var scanning);
+        var isCommandOnly = scanning != null;
+        var channel = scanning?.TrackerChannel;
 
         var filteredSensors = component.ConnectedSensors
-            .Where(pair => isCommandOnly
-                ? pair.Value.IsCommandTracker
-                : !pair.Value.IsCommandTracker)
+            .Where(pair => channel != null
+                ? pair.Value.TrackerChannel == channel
+                : isCommandOnly
+                    ? pair.Value.IsCommandTracker
+                    : !pair.Value.IsCommandTracker)
             .Select(pair => pair.Value)
             .ToList();
         _uiSystem.SetUiState(uid, CrewMonitoringUIKey.Key, new CrewMonitoringState(filteredSensors));

--- a/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
@@ -17,6 +17,7 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Baptr0b0t <152836416+Baptr0b0t@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2026 termertop1gg <pasdnikov777@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -39,6 +40,14 @@ public sealed partial class SuitSensorComponent : Component
     /// </summary>
     [DataField]
     public bool CommandTracker = false;
+
+    /// <summary>
+    ///     Optional channel identifier that groups this sensor with a specific crew monitor.
+    ///     Consoles with a matching <see cref="Content.Goobstation.Shared.CrewMonitoring.CrewMonitorScanningComponent.TrackerChannel"/>
+    ///     will show only sensors on the same channel. Null means "no channel" (legacy behaviour).
+    /// </summary>
+    [DataField]
+    public string? TrackerChannel;
     // GoobStation - End
     /// <summary>
     ///     Choose a random sensor mode when item is spawned.

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -93,6 +93,7 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ignaz "Ian" Kraft <ignaz.k@live.de>
 // SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 termertop1gg <pasdnikov777@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -539,6 +540,7 @@ public sealed class SuitSensorSystem : EntitySystem
 
                 status.Coordinates = GetNetCoordinates(coordinates);
                 status.IsCommandTracker = sensor.CommandTracker; //Goob station
+                status.TrackerChannel = sensor.TrackerChannel; //Goob station
                 break;
         }
 
@@ -569,6 +571,8 @@ public sealed class SuitSensorSystem : EntitySystem
             payload.Add(SuitSensorConstants.NET_TOTAL_DAMAGE_THRESHOLD, status.TotalDamageThreshold);
         if (status.Coordinates != null)
             payload.Add(SuitSensorConstants.NET_COORDINATES, status.Coordinates);
+        if (status.TrackerChannel != null)
+            payload.Add(SuitSensorConstants.NET_TRACKER_CHANNEL, status.TrackerChannel); //Goob station
 
         return payload;
     }
@@ -598,6 +602,7 @@ public sealed class SuitSensorSystem : EntitySystem
         payload.TryGetValue(SuitSensorConstants.NET_TOTAL_DAMAGE, out int? totalDamage);
         payload.TryGetValue(SuitSensorConstants.NET_TOTAL_DAMAGE_THRESHOLD, out int? totalDamageThreshold);
         payload.TryGetValue(SuitSensorConstants.NET_COORDINATES, out NetCoordinates? coords);
+        payload.TryGetValue(SuitSensorConstants.NET_TRACKER_CHANNEL, out string? trackerChannel); //Goob station
 
         var status = new SuitSensorStatus(ownerUid, suitSensorUid, name, job, jobIcon, jobDepartments)
         {
@@ -606,6 +611,7 @@ public sealed class SuitSensorSystem : EntitySystem
             TotalDamageThreshold = totalDamageThreshold,
             Coordinates = coords,
             IsCommandTracker = iscommand,//Goob station
+            TrackerChannel = trackerChannel, //Goob station
         };
         return status;
     }

--- a/Content.Shared/Medical/SuitSensor/SharedSuitSensor.cs
+++ b/Content.Shared/Medical/SuitSensor/SharedSuitSensor.cs
@@ -50,7 +50,7 @@ public sealed class SuitSensorStatus
     public float? DamagePercentage => TotalDamageThreshold == null || TotalDamage == null ? null : TotalDamage / (float) TotalDamageThreshold;
     public NetCoordinates? Coordinates;
     public bool IsCommandTracker = false; ///Goob station
-    public string? TrackerChannel; ///Goob station
+    public string? TrackerChannel; // CorvaxGoob
 }
 
 [Serializable, NetSerializable]
@@ -91,7 +91,7 @@ public static class SuitSensorConstants
     public const string NET_SUIT_SENSOR_UID = "uid";
 
     public const string NET_IS_COMMAND = "iscommand"; ///Goob Sation
-    public const string NET_TRACKER_CHANNEL = "trackerChannel"; ///Goob station
+    public const string NET_TRACKER_CHANNEL = "trackerChannel"; // CorvaxGoob
 
     ///Used by the CrewMonitoringServerSystem to send the status of all connected suit sensors to each crew monitor
     public const string NET_STATUS_COLLECTION = "suit-status-collection";

--- a/Content.Shared/Medical/SuitSensor/SharedSuitSensor.cs
+++ b/Content.Shared/Medical/SuitSensor/SharedSuitSensor.cs
@@ -14,6 +14,7 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Baptr0b0t <152836416+Baptr0b0t@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2026 termertop1gg <pasdnikov777@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -49,6 +50,7 @@ public sealed class SuitSensorStatus
     public float? DamagePercentage => TotalDamageThreshold == null || TotalDamage == null ? null : TotalDamage / (float) TotalDamageThreshold;
     public NetCoordinates? Coordinates;
     public bool IsCommandTracker = false; ///Goob station
+    public string? TrackerChannel; ///Goob station
 }
 
 [Serializable, NetSerializable]
@@ -89,6 +91,7 @@ public static class SuitSensorConstants
     public const string NET_SUIT_SENSOR_UID = "uid";
 
     public const string NET_IS_COMMAND = "iscommand"; ///Goob Sation
+    public const string NET_TRACKER_CHANNEL = "trackerChannel"; ///Goob station
 
     ///Used by the CrewMonitoringServerSystem to send the status of all connected suit sensors to each crew monitor
     public const string NET_STATUS_COLLECTION = "suit-status-collection";


### PR DESCRIPTION
## О PR

Делает `CrewMonitorScanning` (хэндхелд-сканер с do-after) и фильтр консоли мониторинга настраиваемыми из YAML, чтобы разные ручные мониторы (например, парамедиков) могли сосуществовать с BSO-монитором и не видеть одну и ту же выборку.

Раньше система хардкодила `CommandTrackingImplant`, а фильтр консоли был бинарным (`IsCommandTracker`) — из-за этого любые мониторы на этой механике показывали одну и ту же популяцию.

## Изменения

- `CrewMonitorScanningComponent`
  - `Implant` (`EntProtoId`, дефолт `CommandTrackingImplant`) — какой имплант вживлять в цель.
  - `TrackerChannel` (`string?`, дефолт `null`) — опциональная метка канала, по которой фильтрует консоль.
- `CrewMonitorScanningSystem` вживляет `comp.Implant` вместо константы.
- `CrewMonitoringConsoleSystem`: если у консоли есть `CrewMonitorScanning` с `TrackerChannel` — показывает только сенсоры с тем же `TrackerChannel`. Иначе работает прежняя логика по `IsCommandTracker`.
- `SuitSensorComponent` + `SuitSensorStatus` + round-trip по сети (`NET_TRACKER_CHANNEL`) — пробрасывают метку канала от сенсора до консоли.

## Зачем / Медиа

Позволяет контент-авторам чисто YAML-ом заводить дополнительные ручные мониторы (парамедики, медтим, спасатели науки и т.п.), которые видят только своих помеченных:

```yaml
- type: entity
  parent: BaseSubdermalImplant
  id: ParamedicTrackingImplant
  components:
  - type: SuitSensor
    trackerChannel: paramedic
    mode: SensorCords
    controlsLocked: true
    activationContainer: implant
  - type: DeviceNetwork
    deviceNetId: Wireless
    transmitFrequencyId: SuitSensor

- type: entity
  id: HandheldCrewMonitorParamedic
  components:
  - type: CrewMonitorScanning
    implant: ParamedicTrackingImplant
    trackerChannel: paramedic
    whitelist:
      components:
      - HumanoidAppearance
  - type: CrewMonitoringConsole
  - type: DeviceNetwork
    deviceNetId: Wireless
    receiveFrequencyId: CrewMonitor
```

## Технические детали

- Все новые поля опциональные, с безопасными дефолтами. Существующие `HandheldCrewMonitorBSO` и `CommandTrackingImplant` не тронуты и ведут себя идентично прежнему.
- `SuitSensorStatus.TrackerChannel` кладётся в пакет только если не null — лишних байт для базовых костюмных датчиков нет.

## Требования

- [x] Обратная совместимость с существующими прототипами мониторов
- [x] Никаких правок YAML в этом PR — только новые поля в C#

## Ломающие изменения

Нет. Все новые поля по дефолту сохраняют текущее поведение.

## Changelog

:cl: termertop1gg
- add: Ручные мониторы экипажа теперь можно настраивать под произвольный имплант и канал — можно создавать независимые сети отслеживания без правок C#.