### PR TITLE
Rework Ambuzol recipe

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -248,7 +248,6 @@
 
 - type: reaction
   id: Ambuzol
-  maxTemp: 400
   reactants:
     Aluite:
       amount: 1

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -249,17 +249,24 @@
 - type: reaction
   id: Ambuzol
   reactants:
+#    Dylovene: # Commented by CorvaxGoob
+#     amount: 1
+#    Ammonia:
+#      amount: 1
+    ZombieBlood:
+      amount: 3 # CorvaxGoob-changes: 2 > 3
+# CorvaxGoob-changes-start:
     Aluite:
       amount: 1
-    ZombieBlood:
-      amount: 3
     Blood:
       amount: 3
     Calomel:
       amount: 2
+# CorvaxGoob-changes-end.
   products:
     Ambuzol: 4
 
+# CorvaxGoob-changes-start:
 - type: reaction
   id: AmbuzolAshDecomposition
   minTemp: 400
@@ -268,6 +275,7 @@
       amount: 1
   products:
     Ash: 1
+# CorvaxGoob-changes-end.
 
 - type: reaction
   id: AmbuzolPlus

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -248,7 +248,7 @@
 
 - type: reaction
   id: Ambuzol
-  maxTemp: 360
+  maxTemp: 400
   reactants:
     Aluite:
       amount: 1
@@ -257,11 +257,11 @@
     Calomel:
       amount: 2
   products:
-    Ambuzol: 2
+    Ambuzol: 3
 
 - type: reaction
   id: AmbuzolAshDecomposition
-  minTemp: 360
+  minTemp: 400
   reactants:
     Ambuzol:
       amount: 1

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -254,10 +254,12 @@
       amount: 1
     ZombieBlood:
       amount: 3
+    Blood:
+      amount: 3
     Calomel:
       amount: 2
   products:
-    Ambuzol: 3
+    Ambuzol: 4
 
 - type: reaction
   id: AmbuzolAshDecomposition

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -248,15 +248,25 @@
 
 - type: reaction
   id: Ambuzol
+  maxTemp: 360
   reactants:
-    Dylovene:
-      amount: 1
-    Ammonia:
+    Aluite:
       amount: 1
     ZombieBlood:
+      amount: 3
+    Calomel:
       amount: 2
   products:
-    Ambuzol: 4
+    Ambuzol: 2
+
+- type: reaction
+  id: AmbuzolAshDecomposition
+  minTemp: 360
+  reactants:
+    Ambuzol:
+      amount: 1
+  products:
+    Ash: 1
 
 - type: reaction
   id: AmbuzolPlus


### PR DESCRIPTION
## Описание PR
Переработан рецепт амбузола и добавлено его термическое разложение.

**Старый рецепт:** 1 Dylovene + 1 Ammonia + 2 ZombieBlood = 4 Ambuzol.
**Новый рецепт:** 1 Aluite + 3 ZombieBlood + 3 Blood + 2 Calomel = 4 Ambuzol.
**Новое:** при температуре выше 400K амбузол распадается в пепел (`AmbuzolAshDecomposition`).

## Почему / Баланс
Старый рецепт был тривиальным — двух базовых реагентов и крови зомби достаточно, чтобы массово штамповать антизомби‑лекарство. Это обесценивало угрозу зомби‑события: достаточно одной банки Dylovene/Ammonia + добычи минимума заражённой крови, и эпидемия заканчивается.

Новый рецепт:
- Добавляет токсичный Aluite, Calomel, требует обычную кровь (Blood) и сохраняет ZombieBlood как ключевой ингредиент темы.
- Термическое ограничение (>400K → пепел) добавляет риск при варке: если химик зазевался с нагревателем — партия превращается в Ash.

## Технические детали
Изменения в `Resources/Prototypes/Recipes/Reactions/medicine.yml`:
- Изменены реагенты и выход реакции `Ambuzol`.
- Добавлена новая реакция `AmbuzolAshDecomposition` с `minTemp: 400`, превращающая 1 Ambuzol → 1 Ash.

## Медиа
PR не вносит визуальных или геймплейно‑демонстрационных изменений (рецепт химии). Демонстрация не требуется.

## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Критические изменения
Нет программных API‑изменений. Существующие инструкции/гайды по варке амбузола устареют — игрокам придётся переучиться.

**Список изменений**
:cl:
- tweak: Рецепт амбузола изменён: теперь требует 1 алюит + 3 крови зомби + 3 крови + 2 каломели и даёт 4 единицы.
- add: Амбузол распадается в пепел при температуре выше 400K.