### PR TITLE
Fix anomaly rock spawn

### DIFF
--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -522,6 +522,7 @@ public abstract class SharedAnomalySystem : EntitySystem
             }
 
             resultList.Add(tileref);
+            tilerefs.Remove(tileref); //CorvaxGoob-RockSpawnFix
         }
         return resultList;
     }


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## Описание PR
Аномалии подобные каменной больше не спавнят по 10 камней на тайл из-за чего их фиг сломаешь

## Почему / Баланс
так явно не задумано

## Медиа
До:

https://github.com/user-attachments/assets/65b3d7e2-cfb4-4bee-8eae-d863a85076a4

После:

https://github.com/user-attachments/assets/82e61a8f-385b-4702-8bf4-adb12f84245b

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->


**Список изменений**
:cl:
- fix: Каменные аномалии больше не спавнят несколько камней на тайл

