### PR TITLE
TapeRecorder-Fix

### DIFF
--- a/Content.Goobstation.Server/TapeRecorder/TapeRecorderSystem.cs
+++ b/Content.Goobstation.Server/TapeRecorder/TapeRecorderSystem.cs
@@ -129,10 +129,13 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
             var name = message.Name ?? ent.Comp.DefaultName;
             var time = TimeSpan.FromSeconds((double) message.Timestamp);
             //CorvaxGoob-RecorderLanguage-Fix-Start
-            var information = message.Message;
-            if (message.Language != ent.Comp.TranscriptionLanguage)
-                information = Loc.GetString("tape-recorded-print-transcription-failure");
-
+            var information = Loc.GetString("tape-recorded-print-transcription-failure");
+            foreach (var language in ent.Comp.TranscriptionLanguages)
+                if (message.Language == language)
+                {
+                    information = message.Message;
+                    break;
+                }
             text.AppendLine(Loc.GetString("tape-recorder-print-message-text",
                 ("time", time.ToString(@"hh\:mm\:ss")),
                 ("source", name),

--- a/Content.Goobstation.Server/TapeRecorder/TapeRecorderSystem.cs
+++ b/Content.Goobstation.Server/TapeRecorder/TapeRecorderSystem.cs
@@ -8,9 +8,12 @@ using Content.Server.Chat.Systems;
 using Content.Server.Hands.Systems;
 using Content.Server.Speech;
 using Content.Server.Speech.Components;
+using Content.Server._EinsteinEngines.Language; //CorvaxGoob-RecorderLanguage-Fix
 using Content.Shared.Chat;
 using Content.Shared.Paper;
 using Content.Shared.Speech;
+using Content.Shared._EinsteinEngines.Language.Components; //CorvaxGoob-RecorderLanguage-Fix
+using Content.Shared._EinsteinEngines.Language; //CorvaxGoob-RecorderLanguage-Fix
 using Content.Goobstation.Shared.TapeRecorder;
 using Robust.Shared.Prototypes;
 using System.Text;
@@ -23,6 +26,7 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
     [Dependency] private readonly HandsSystem _hands = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly PaperSystem _paper = default!;
+    [Dependency] private readonly LanguageSystem _language = default!; //CorvaxGoob-RecorderLanguage-Fix
 
     public override void Initialize()
     {
@@ -40,6 +44,7 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
     {
         var voice = EnsureComp<VoiceOverrideComponent>(ent);
         var speech = EnsureComp<SpeechComponent>(ent);
+        var language = EnsureComp<LanguageSpeakerComponent>(ent); //CorvaxGoob-RecorderLanguage-Fix
 
         foreach (var message in tape.RecordedData)
         {
@@ -51,6 +56,8 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
             // TODO: mimic the exact string chosen when the message was recorded
             var verb = message.Verb ?? SharedChatSystem.DefaultSpeechVerb;
             speech.SpeechVerb = _proto.Index<SpeechVerbPrototype>(verb);
+            language.CurrentLanguage = message.Language; //CorvaxGoob-RecorderLanguage-Fix
+
             //Play the message
             _chat.TrySendInGameICMessage(ent, message.Message, InGameICChatType.Speak, false);
         }
@@ -81,7 +88,10 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
         //Add a new entry to the tape
         var verb = _chat.GetSpeechVerb(args.Source, args.Message);
         var name = nameEv.VoiceName;
-        cassette.Comp.Buffer.Add(new TapeCassetteRecordedMessage(cassette.Comp.CurrentPosition, name, verb, args.Message));
+        //CorvaxGoob-RecorderLanguage-Fix-Start
+        var language = _language.GetLanguage(args.Source);
+        cassette.Comp.Buffer.Add(new TapeCassetteRecordedMessage(cassette.Comp.CurrentPosition, name, verb, args.Message, language));
+        //CorvaxGoob-RecorderLanguage-Fix-End
     }
 
     private void OnPrintMessage(Entity<TapeRecorderComponent> ent, ref PrintTapeRecorderMessage args)
@@ -118,11 +128,16 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
         {
             var name = message.Name ?? ent.Comp.DefaultName;
             var time = TimeSpan.FromSeconds((double) message.Timestamp);
+            //CorvaxGoob-RecorderLanguage-Fix-Start
+            var information = message.Message;
+            if (message.Language != ent.Comp.TranscriptionLanguage)
+                information = Loc.GetString("tape-recorded-print-transcription-failure");
 
             text.AppendLine(Loc.GetString("tape-recorder-print-message-text",
                 ("time", time.ToString(@"hh\:mm\:ss")),
                 ("source", name),
-                ("message", message.Message)));
+                ("message", information)));
+            //CorvaxGoob-RecorderLanguage-Fix-End
         }
         text.AppendLine();
         text.Append(Loc.GetString("tape-recorder-print-end-text"));

--- a/Content.Goobstation.Shared/TapeRecorder/Components/TapeRecorderComponent.cs
+++ b/Content.Goobstation.Shared/TapeRecorder/Components/TapeRecorderComponent.cs
@@ -92,5 +92,5 @@ public sealed partial class TapeRecorderComponent : Component
     /// In which language the transcription will be made
     /// </summary>
     [DataField]
-    public ProtoId<LanguagePrototype> TranscriptionLanguage;  //CorvaxGoob-RecorderLanguage-Fix
+    public List<ProtoId<LanguagePrototype>> TranscriptionLanguages;  //CorvaxGoob-RecorderLanguage-Fix
 }

--- a/Content.Goobstation.Shared/TapeRecorder/Components/TapeRecorderComponent.cs
+++ b/Content.Goobstation.Shared/TapeRecorder/Components/TapeRecorderComponent.cs
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared._EinsteinEngines.Language; //CorvaxGoob-RecorderLanguage-Fix
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -86,4 +87,10 @@ public sealed partial class TapeRecorderComponent : Component
     {
         Params = AudioParams.Default.WithVolume(-2f).WithMaxDistance(3f)
     };
+
+    /// <summary>
+    /// In which language the transcription will be made
+    /// </summary>
+    [DataField]
+    public ProtoId<LanguagePrototype> TranscriptionLanguage;  //CorvaxGoob-RecorderLanguage-Fix
 }

--- a/Content.Goobstation.Shared/TapeRecorder/TapeCasetteRecordedMessage.cs
+++ b/Content.Goobstation.Shared/TapeRecorder/TapeCasetteRecordedMessage.cs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared._EinsteinEngines.Language; //CorvaxGoob-RecorderLanguage-Fix
 using Content.Shared.Speech;
 using Robust.Shared.Prototypes;
 
@@ -39,12 +40,19 @@ public sealed partial class TapeCassetteRecordedMessage : IComparable<TapeCasset
     [DataField]
     public string Message = string.Empty;
 
-    public TapeCassetteRecordedMessage(float timestamp, string name, ProtoId<SpeechVerbPrototype> verb, string message)
+    /// <summary>
+    /// spoken language
+    /// </summary>
+    [DataField]
+    public ProtoId<LanguagePrototype> Language;  //CorvaxGoob-RecorderLanguage-Fix
+
+    public TapeCassetteRecordedMessage(float timestamp, string name, ProtoId<SpeechVerbPrototype> verb, string message, ProtoId<LanguagePrototype> language) //CorvaxGoob-RecorderLanguage-Fix
     {
         Timestamp = timestamp;
         Name = name;
         Verb = verb;
         Message = message;
+        Language = language; //CorvaxGoob-RecorderLanguage-Fix
     }
 
     public int CompareTo(TapeCassetteRecordedMessage? other)

--- a/Resources/Locale/en-US/_CorvaxGoob/taperecorder/taperecorder.ftl
+++ b/Resources/Locale/en-US/_CorvaxGoob/taperecorder/taperecorder.ftl
@@ -1,0 +1,1 @@
+tape-recorded-print-transcription-failure = [bold][color=red]Transcription Failure[/color][/bold]

--- a/Resources/Locale/ru-RU/_corvaxgoob/taperecorder/taperecorder.ftl
+++ b/Resources/Locale/ru-RU/_corvaxgoob/taperecorder/taperecorder.ftl
@@ -1,0 +1,1 @@
+tape-recorded-print-transcription-failure = [bold][color=red]Транскрипция невозможна[/color][/bold] 

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
@@ -19,7 +19,7 @@
   - type: Item
     size: Small
   - type: TapeRecorder
-    transcriptionLanguages: [TauCetiBasic, Canilunzt] #CorvaxGoob-RecorderLanguage-Fix
+    transcriptionLanguages: [TauCetiBasic] #CorvaxGoob-RecorderLanguage-Fix
   - type: ActiveListener
     range: 4
   - type: UseDelay

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
@@ -19,7 +19,7 @@
   - type: Item
     size: Small
   - type: TapeRecorder
-    transcriptionLanguage: TauCetiBasic #CorvaxGoob-RecorderLanguage-Fix
+    transcriptionLanguages: [TauCetiBasic, Canilunzt] #CorvaxGoob-RecorderLanguage-Fix
   - type: ActiveListener
     range: 4
   - type: UseDelay

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
@@ -19,6 +19,7 @@
   - type: Item
     size: Small
   - type: TapeRecorder
+    transcriptionLanguage: TauCetiBasic #CorvaxGoob-RecorderLanguage-Fix
   - type: ActiveListener
     range: 4
   - type: UseDelay


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## Описание PR
Магнитофон теперь запоминает язык который услышал и корректно повторяет его, при печатании если язык не соответствует указанному в прототипе, пишет ошибку

## Почему / Баланс
Так ведут себя магнитофоны в реальной жизни

## Технические детали
При записывании сохранят язык, при проигрывании переключается между записанными языками.

## Медиа
<img width="497" height="155" alt="доход" src="https://github.com/user-attachments/assets/50639bf7-3a58-4c34-9c81-39760d09a0f3" />


## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl:
- fix: Магнитофон запоминает язык говорящего

