### PR TITLE
PlantAnalyzer теперь можно положить в ClothingBeltPlant (пояс ботаников)

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -526,7 +526,7 @@
   - type: Storage
     whitelist:
       tags:
-        # - PlantAnalyzer
+        - PlantAnalyzer # CorvaxGoob
         - PlantSampleTaker
         - BotanyShovel
         - BotanyHoe
@@ -547,10 +547,12 @@
         whitelist:
           tags:
           - BotanyHatchet
-      # hydro:
-      #   whitelist:
-      #     tags:
-      #     - PlantAnalyzer # Dunno what to put here, should be aight.
+      # CorvaxGoob start
+      hydro:
+        whitelist:
+          tags:
+          - PlantAnalyzer
+      # CorvaxGoob end
       hoe:
         whitelist:
           tags:
@@ -763,7 +765,7 @@
     - neck # CorvaxGoob start
   - type: Storage
     grid:
-    - 0,0,5,1 #corvaxgoob 
+    - 0,0,5,1 #corvaxgoob
   # Goobstation
 #    whitelist:
 #      components:

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -526,7 +526,7 @@
   - type: Storage
     whitelist:
       tags:
-        - PlantAnalyzer # CorvaxGoob
+        - PlantAnalyzer
         - PlantSampleTaker
         - BotanyShovel
         - BotanyHoe
@@ -547,12 +547,10 @@
         whitelist:
           tags:
           - BotanyHatchet
-      # CorvaxGoob start
       hydro:
         whitelist:
           tags:
-          - PlantAnalyzer
-      # CorvaxGoob end
+          - PlantAnalyzer # Dunno what to put here, should be aight.
       hoe:
         whitelist:
           tags:


### PR DESCRIPTION
## Почему / Баланс
Довольно странно, что инструмент для ботаников нельзя положить в их пояс.

## Технические детали
В вайтлист пояса ботаника раскомментировал код тега PlantAnalyzer и раскомментировал его визуальное отображение.

## Медиа
<img width="192" height="96" alt="Belt_PlantAnalyzer" src="https://github.com/user-attachments/assets/e63067cb-ee44-4ac7-a2ac-f0cd6f6123d2" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
- Раскомментирование кода в ванильном файле Resources\Prototypes\Entities\Clothing\Belt\belts.yml
  
**Список изменений**
:cl: KAVALDi
- add: Добавлена возможность положить Анализатор растений в Пояс ботаника
