### PR TITLE
Изменение требуемого времени для смотрителя

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -140,7 +140,7 @@
       time: 18000 #5 hrs
     - !type:RoleTimeRequirement
       role: JobBrigmedic
-      time: 3600 #1 hrs
+      time: 3600 #CorvaxGoob 18000 -> 3600 1hrs
     - !type:DepartmentTimeRequirement
       department: Security
       time: 36000 # 10 hrs

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -140,7 +140,7 @@
       time: 18000 #5 hrs
     - !type:RoleTimeRequirement
       role: JobBrigmedic
-      time: 18000 #5 hrs
+      time: 3600 #1 hrs
     - !type:DepartmentTimeRequirement
       department: Security
       time: 36000 # 10 hrs


### PR DESCRIPTION
## Описание PR
- Для разблокировки роли смотрителя теперь требуется 1 час на бригмедике.

## Почему / Баланс
Предложение/Идея: https://discord.com/channels/919301044784226385/1499413033091469453

## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

**Список изменений**
:cl: drunkmaster:
- tweak: Изменено время для разблокировки роли смотрителя.