### PR TITLE
Fix stasis

### DIFF
--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
@@ -752,15 +752,16 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
 
     public void RemoveAllChangelingEquipment(EntityUid target, ChangelingIdentityComponent comp)
     {
-        // check if there's no entities or all entities are null
-        if (comp.Equipment.Values.Count == 0
-        || comp.Equipment.Values.All(ent => ent == null ? true : false))
+        if (comp.Equipment.Count == 0) // CorvaxGoob edit
             return;
 
         foreach (var equip in comp.Equipment.Values)
             QueueDel(equip);
 
+        comp.Equipment.Clear(); // CorvaxGoob edit
+
         PlayMeatySound(target, comp);
+
     }
 
     #endregion


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Ko4ergaPunk <nikitako4erga3i5@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!--- LICENSE: AGPL -->
## Описание PR
Исправлен баг https://discord.com/channels/919301044784226385/1500232752971382915

Упрощён код метода RemoveAllChangelingEquipment

## Технические детали
При входе в стазис вызывалась RemoveAllChangelingEquipment, которая удаляла сущности оружия через QueueDel, но не очищала словарь comp.Equipment. После выхода из стазиса TryToggleItem считал что оружие все еще извлечено и делал действие убрать вместо достать.
Убрана проверка All(ent => ent == null ? true : false) так как QueueDel(EntityUid?) уже безопасно обрабатывает null и удалённые ентити.
Условие Count == 0 || All(...) заменено на простой if (comp.Equipment.Count == 0) return;

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
:cl:
- fix: Генокрад снова достает оружие с первой попытки после стазиса.

