### PR TITLE
Polymorph fix

### DIFF
--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -118,6 +118,7 @@ using Content.Shared.Destructible;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory;
+using Content.Shared.Interaction.Components; // CorvaxGoob edit
 using Content.Shared.Mind;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
@@ -493,6 +494,22 @@ public sealed partial class PolymorphSystem : EntitySystem
             _mindSystem.TransferTo(mindId, child, mind: mind);
 
         _tag.RemoveTag(uid, SharedBindSoulSystem.IgnoreBindSoulTag); // Goobstation
+
+        // CorvaxGoob edit start - items that failed to transfer must not disappear to paused map
+        if (_inventory.TryGetContainerSlotEnumerator(uid, out var safetyEnum))
+        {
+            while (safetyEnum.MoveNext(out var slot))
+            {
+                if (slot.ContainedEntity is { } item && !HasComp<UnremoveableComponent>(item))
+                    _inventory.TryUnequip(uid, slot.ID, silent: true, force: true);
+            }
+        }
+        foreach (var held in _hands.EnumerateHeld(uid))
+        {
+            if (!HasComp<UnremoveableComponent>(held))
+                _hands.TryDrop(uid, held, checkActionBlocker: false);
+        }
+        // CorvaxGoob edit end
 
         //Ensures a map to banish the entity to
         EnsurePausedMap();


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Ko4ergaPunk <nikitako4erga3i5@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Багфикс https://discord.com/channels/919301044784226385/1499227719484051596

## Почему / Баланс
При полиморфе инвентарь переносится через TransferEntityInventories с force: false. Если TryUnequip не срабатывал, то предметы оставались в инвентаре начального персонажа. После переноса разума оригинал уходил на paused мапу вместе со всеми оставшимися предметами, которые таким образом исчезали. 
Теперь предметы, которые не удалось перенести обычным путем, принудительно падают рядом с игроком перед уходом оригинала на paused мапу. 
Предметы с UnremoveableComponent намеренно оставил без изменений так что они уходят вместе с оригиналом.

## Технические детали
В Content.Server/Polymorph/Systems/PolymorphSystem.cs перед EnsurePausedMap(), добавлен доп блок. 
Перебираются все оставшиеся слоты инвентаря через TryGetContainerSlotEnumerator. 
Для каждого предмета без UnremoveableComponent вызывается TryUnequip с force: true.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl:
- fix: Предметы больше не исчезают при смене персонажа(расы и тд) будучи генокрадом или с помощью реагентов.

