### PR TITLE
The Shawshank Redemption

### DIFF
--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -76,6 +76,10 @@ namespace Content.Shared.Damage
         // Goobstation
         [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<FixedPoint2, DamageTypePrototype>))]
         public Dictionary<string, FixedPoint2> WoundSeverityMultipliers { get; set; } = new();
+		
+        // CorvaxGoob
+        [DataField]
+        public bool BypassFlatReductions { get; set; }
 
         /// <summary>
         ///     Returns a sum of the damage values.
@@ -146,6 +150,7 @@ namespace Content.Shared.Damage
             ArmorPenetration = damageSpec.ArmorPenetration; // Goobstation
             PartDamageVariation = damageSpec.PartDamageVariation; // Goobstation
             WoundSeverityMultipliers = new(damageSpec.WoundSeverityMultipliers);
+			BypassFlatReductions = damageSpec.BypassFlatReductions; // CorvaxGoob
         }
 
         /// <summary>
@@ -215,7 +220,38 @@ namespace Content.Shared.Damage
 
             return newDamage;
         }
+// CorvaxGoob-changes-start:
+        public static DamageSpecifier ApplyModifierSet(DamageSpecifier damageSpec, DamageModifierSet modifierSet, bool bypassFlatReductions)
+        {
+            if (!bypassFlatReductions)
+                return ApplyModifierSet(damageSpec, modifierSet);
 
+            DamageSpecifier newDamage = new(damageSpec.ArmorPenetration, damageSpec.PartDamageVariation, damageSpec.WoundSeverityMultipliers);
+            newDamage.DamageDict.EnsureCapacity(damageSpec.DamageDict.Count);
+
+            foreach (var (key, value) in damageSpec.DamageDict)
+            {
+                if (value == 0)
+                    continue;
+
+                if (value < 0)
+                {
+                    newDamage.DamageDict[key] = value;
+                    continue;
+                }
+
+                float newValue = value.Float();
+
+                if (modifierSet.Coefficients.TryGetValue(key, out var coefficient))
+                    newValue *= coefficient;
+
+                if (newValue != 0)
+                    newDamage.DamageDict[key] = FixedPoint2.New(newValue);
+            }
+
+            return newDamage;
+        }
+// CorvaxGoob-changes-end.
         /// <summary>
         ///     Reduce (or increase) damages by applying multiple modifier sets.
         /// </summary>

--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -187,7 +187,7 @@ namespace Content.Shared.Damage
         ///     Only applies resistance to a damage type if it is dealing damage, not healing.
         ///     This will never convert damage into healing.
         /// </remarks>
-        public static DamageSpecifier ApplyModifierSet(DamageSpecifier damageSpec, DamageModifierSet modifierSet)
+        public static DamageSpecifier ApplyModifierSet(DamageSpecifier damageSpec, DamageModifierSet modifierSet, bool bypassFlatReductions = false) // CorvaxGoob : bypassFlatReductions
         {
             // Make a copy of the given data. Don't modify the one passed to this function. I did this before, and weapons became
             // duller as you hit walls. Neat, but not FixedPoint2ended. And confusing, when you realize your fists don't work no
@@ -208,7 +208,7 @@ namespace Content.Shared.Damage
 
                 float newValue = value.Float();
 
-                if (modifierSet.FlatReduction.TryGetValue(key, out var reduction))
+                if (!bypassFlatReductions && modifierSet.FlatReduction.TryGetValue(key, out var reduction)) // CorvaxGoob : bypassFlatReductions
                     newValue = Math.Max(0f, newValue - reduction); // flat reductions can't heal you
 
                 if (modifierSet.Coefficients.TryGetValue(key, out var coefficient))
@@ -220,38 +220,7 @@ namespace Content.Shared.Damage
 
             return newDamage;
         }
-// CorvaxGoob-changes-start:
-        public static DamageSpecifier ApplyModifierSet(DamageSpecifier damageSpec, DamageModifierSet modifierSet, bool bypassFlatReductions)
-        {
-            if (!bypassFlatReductions)
-                return ApplyModifierSet(damageSpec, modifierSet);
 
-            DamageSpecifier newDamage = new(damageSpec.ArmorPenetration, damageSpec.PartDamageVariation, damageSpec.WoundSeverityMultipliers);
-            newDamage.DamageDict.EnsureCapacity(damageSpec.DamageDict.Count);
-
-            foreach (var (key, value) in damageSpec.DamageDict)
-            {
-                if (value == 0)
-                    continue;
-
-                if (value < 0)
-                {
-                    newDamage.DamageDict[key] = value;
-                    continue;
-                }
-
-                float newValue = value.Float();
-
-                if (modifierSet.Coefficients.TryGetValue(key, out var coefficient))
-                    newValue *= coefficient;
-
-                if (newValue != 0)
-                    newDamage.DamageDict[key] = FixedPoint2.New(newValue);
-            }
-
-            return newDamage;
-        }
-// CorvaxGoob-changes-end.
         /// <summary>
         ///     Reduce (or increase) damages by applying multiple modifier sets.
         /// </summary>

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -518,8 +518,11 @@ namespace Content.Shared.Damage
                 if (damageable.DamageModifierSetId != null &&
                     _prototypeManager.TryIndex(damageable.DamageModifierSetId, out var modifierSet))
                 {
+//                    damage = DamageSpecifier.ApplyModifierSet(damage, 
+//                        DamageSpecifier.PenetrateArmor(modifierSet, damage.ArmorPenetration)); // Goob edit // Commented by CorvaxGoob
                     damage = DamageSpecifier.ApplyModifierSet(damage,
-                        DamageSpecifier.PenetrateArmor(modifierSet, damage.ArmorPenetration)); // Goob edit
+                        DamageSpecifier.PenetrateArmor(modifierSet, damage.ArmorPenetration),
+                        damage.BypassFlatReductions); // CorvaxGoob
                 }
 
                 if (TryComp(uid, out BodyPartComponent? bodyPart))

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -235,6 +235,11 @@ public sealed partial class MeleeWeaponComponent : Component
     // Goobstation
     [DataField, AutoNetworkedField]
     public float HeavyAttackWoundMultiplier = 0.5f;
+
+    // CorvaxGoob-changes-start:
+    [DataField, AutoNetworkedField]
+    public bool BypassFlatReductions = false;
+    // CorvaxGoob-changes-end.
 }
 
 /// <summary>

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -768,6 +768,12 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         RaiseLocalEvent(target.Value, attackedEvent);
         var modifiedDamage = DamageSpecifier.ApplyModifierSets(damage + hitEvent.BonusDamage + attackedEvent.BonusDamage, hitEvent.ModifiersList);
         modifiedDamage = DamageSpecifier.ApplyModifierSets(modifiedDamage, attackedEvent.ModifiersList); // Goobstation
+		
+            // CorvaxGoob-changes-start:
+            if (component.BypassFlatReductions)
+                modifiedDamage.BypassFlatReductions = true;
+            // CorvaxGoob-changes-end
+
         var damageResult = Damageable.TryChangeDamage(target, modifiedDamage, origin: user, partMultiplier: component.ClickPartDamageMultiplier); // Shitmed Change
         var comboEv = new ComboAttackPerformedEvent(user, target.Value, meleeUid, ComboAttackType.Harm);
         RaiseLocalEvent(user, comboEv);
@@ -944,6 +950,12 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             RaiseLocalEvent(entity, attackedEvent);
             var modifiedDamage = DamageSpecifier.ApplyModifierSets(damage + hitEvent.BonusDamage + attackedEvent.BonusDamage, hitEvent.ModifiersList);
             modifiedDamage = DamageSpecifier.ApplyModifierSets(modifiedDamage, attackedEvent.ModifiersList); // Goobstation
+
+            // CorvaxGoob-changes-start
+            if (component.BypassFlatReductions)
+                modifiedDamage.BypassFlatReductions = true;
+            // CorvaxGoob-changes-end		
+
             foreach (var type in modifiedDamage.DamageDict.Keys) // Goobstation
             {
                 if (!modifiedDamage.WoundSeverityMultipliers.TryAdd(type, component.HeavyAttackWoundMultiplier))

--- a/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
@@ -92,10 +92,10 @@
     bypassFlatReductions: true # CorvaxGoob
     animationRotation: 180 # WWDP
     wideAnimationRotation: 180
-    attackRate: 1 # CorvaxGoob: 1.5 > 1
+    attackRate: 1 # CorvaxGoob-changes: 1.5 > 1
     damage:
       types:
-        Piercing: 5
+        Piercing: 2 # CorvaxGoob-changes: 5 > 2
         Structural: 0.1 # CorvaxGoob
   - type: Tweezers # Shitmed: Forks are better than spoons
     speed: 0.35

--- a/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
@@ -89,12 +89,14 @@
     types:
     - Fork
   - type: MeleeWeapon
+    bypassFlatReductions: true # CorvaxGoob
     animationRotation: 180 # WWDP
     wideAnimationRotation: 180
-    attackRate: 1.5
+    attackRate: 1 # CorvaxGoob: 1.5 > 1
     damage:
       types:
         Piercing: 5
+        Structural: 0.1 # CorvaxGoob
   - type: Tweezers # Shitmed: Forks are better than spoons
     speed: 0.35
 
@@ -157,7 +159,7 @@
     types:
     - Spoon
   - type: Shovel
-    speedModifier: 0.1 # you can try
+    speedModifier: 0.03 # you can try # CorvaxGoob-changes: 0.1 > 0.03
   - type: ReactionMixer
     mixMessage: "spoon-mixing-success"
     timeToMix: 0.5


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Ko4ergaPunk <nikitako4erga3i5@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
- Вилке добавлен структурный урон 0.1 единиц. Скорость атаки и урон порезами немного понижены
- Пластиковой ложке понижена скорость копания, дабы она отличалась от железной.

## Почему / Баланс
- Предложка https://discord.com/channels/919301044784226385/1500133933030047845

## Технические детали
Щиткодище в чистом виде, урон вилки по стенам почему-то удваивается. Так или иначе, я сделал всё что мог.
- В `MeleeWeaponComponent` добавлен `BypassFlatReductions` - игнорирование flat reduction с сохранением коэффициентов.
- В `DamageSpecifier` добавлен `ApplyModifierSet` для работы с `BypassFlatReductions`

## Медиа
<img width="1168" height="760" alt="image" src="https://github.com/user-attachments/assets/55ce983a-766e-438c-9cbf-cc562a78be29" />


## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->


**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl: Pcolik505:
- tweak: Вилкой теперь можно ломать стены!
- tweak: Понижена скорость копания пластиковой ложки.
