### PR TITLE
Shared Internal Resources optimization

### DIFF
--- a/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesData.cs
+++ b/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesData.cs
@@ -32,7 +32,7 @@ public sealed partial class InternalResourcesData
     /// The thresholds at which InternalResourcesThresholdMetEvent will be raised.
     /// </summary>
     [DataField]
-    public Dictionary<string, (float, bool)>? Thresholds;
+    public Dictionary<string, ThresholdData>? Thresholds; // CorvaxGoob edit
 
     /// <summary>
     /// Prototype with visual information of internal resources
@@ -44,7 +44,7 @@ public sealed partial class InternalResourcesData
         float maxAmount,
         float regenerationRate,
         float startingAmount,
-        Dictionary<string, (float, bool)>? thresholds,
+        Dictionary<string, ThresholdData>? thresholds, // CorvaxGoob edit
         string protoId)
     {
         CurrentAmount = startingAmount;

--- a/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesData.cs
+++ b/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesData.cs
@@ -1,5 +1,6 @@
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Content.Shared._CorvaxGoob.InternalResources.Data; // CorvaxGoob edit
 
 namespace Content.Goobstation.Shared.InternalResources.Data;
 

--- a/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesThresholdsPrototype.cs
+++ b/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesThresholdsPrototype.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.Prototypes;
+using Content.Shared._CorvaxGoob.InternalResources.Data; // CorvaxGoob edit
 
 namespace Content.Goobstation.Shared.InternalResources.Data;
 

--- a/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesThresholdsPrototype.cs
+++ b/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesThresholdsPrototype.cs
@@ -12,9 +12,9 @@ public sealed class InternalResourcesThresholdsPrototype : IPrototype
     public string ID { get; private set; } = default!;
 
     /// <summary>
-    /// Float is the percentage from 0 to 1. 
+    /// Float is the percentage from 0 to 1.
     /// Bool is if the threshold was met.
     /// </summary>
     [DataField]
-    public Dictionary<string, (float, bool)>? Thresholds;
+    public Dictionary<string, ThresholdData>? Thresholds; // CorvaxGoob edit
 }

--- a/Content.Goobstation.Shared/InternalResources/Data/ThresholdData.cs
+++ b/Content.Goobstation.Shared/InternalResources/Data/ThresholdData.cs
@@ -1,0 +1,21 @@
+// CorvaxGoob
+using Robust.Shared.Serialization;
+
+namespace Content.Goobstation.Shared.InternalResources.Data;
+
+[Serializable, NetSerializable]
+[DataDefinition]
+public sealed partial class ThresholdData
+{
+    /// <summary>
+    /// The threshold percentage from 0 to 1.
+    /// </summary>
+    [DataField]
+    public float Percentage;
+
+    /// <summary>
+    /// Whether the threshold has been met.
+    /// </summary>
+    [DataField]
+    public bool Met;
+}

--- a/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesSystem.cs
+++ b/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesSystem.cs
@@ -273,9 +273,12 @@ public abstract class SharedInternalResourcesSystem : EntitySystem
         return Resolve(uid, ref component) && component.HasResourceData(type, out data);
     }
 
+
+
     /// <summary>
     /// Handles internal resources regeneration
     /// </summary>
+    // СorvaxGoob edit start
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -288,6 +291,8 @@ public abstract class SharedInternalResourcesSystem : EntitySystem
         var query = EntityQueryEnumerator<InternalResourcesComponent>();
         while (query.MoveNext(out var uid, out var resourcesComp))
         {
+            var dirtyNeeded = false;
+
             foreach (var resourceData in resourcesComp.CurrentInternalResources)
             {
                 var modEv = new InternalResourcesRegenModifierEvent(
@@ -296,34 +301,34 @@ public abstract class SharedInternalResourcesSystem : EntitySystem
                     resourceData.RegenerationRate);
                 RaiseLocalEvent(uid, ref modEv);
 
+
                 TryUpdateResourcesAmount(uid, resourceData, modEv.Modifier, resourcesComp);
 
                 if (resourceData.Thresholds == null)
                     continue;
 
-                var thresholdsArray = resourceData.Thresholds.Keys.ToArray();
-                foreach (var key in thresholdsArray)
+                foreach (var (key, threshold) in resourceData.Thresholds)
                 {
-                    var threshold = resourceData.Thresholds[key];
-                    // threshold.Item1 is the threshold percentage
-                    // threshold.Item2 is the bool for the threshold having been met
+                    var scaledAmount = resourceData.MaxAmount * threshold.Percentage;
 
-                    var scaledAmount = resourceData.MaxAmount * threshold.Item1;
-
-                    if (!threshold.Item2 // threshold needs to not have been met already
-                        && resourceData.CurrentAmount <= scaledAmount)
+                    if (!threshold.Met && resourceData.CurrentAmount <= scaledAmount)
                     {
                         var threshEv = new InternalResourcesThresholdMetEvent(uid, resourceData, key);
                         RaiseLocalEvent(uid, ref threshEv);
                     }
 
-                    threshold.Item2 = resourceData.CurrentAmount <= scaledAmount;
-
-                    resourceData.Thresholds[key] = threshold;
+                    var newMet = resourceData.CurrentAmount <= scaledAmount;
+                    if (newMet != threshold.Met)
+                    {
+                        threshold.Met = newMet;
+                        dirtyNeeded = true;
+                    }
                 }
-
-                Dirty(uid, resourcesComp);
             }
+
+            if (dirtyNeeded)
+                Dirty(uid, resourcesComp);
         }
-    }
+        // СorvaxGoob edit end
+}
 }

--- a/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesSystem.cs
+++ b/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesSystem.cs
@@ -2,6 +2,7 @@ using Content.Goobstation.Shared.Alert.Events;
 using Content.Goobstation.Shared.InternalResources.Components;
 using Content.Goobstation.Shared.InternalResources.Data;
 using Content.Goobstation.Shared.InternalResources.Events;
+using Content.Shared._CorvaxGoob.InternalResources.Data; // CorvaxGoob edit
 using Content.Shared.Alert;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;

--- a/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesSystem.cs
+++ b/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesSystem.cs
@@ -6,7 +6,6 @@ using Content.Shared.Alert;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Content.Goobstation.Shared.InternalResources.EntitySystems;
 public abstract class SharedInternalResourcesSystem : EntitySystem
@@ -273,12 +272,10 @@ public abstract class SharedInternalResourcesSystem : EntitySystem
         return Resolve(uid, ref component) && component.HasResourceData(type, out data);
     }
 
-
-
     /// <summary>
     /// Handles internal resources regeneration
     /// </summary>
-    // СorvaxGoob edit start
+    // CorvaxGoob edit start
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -300,7 +297,6 @@ public abstract class SharedInternalResourcesSystem : EntitySystem
                     resourceData,
                     resourceData.RegenerationRate);
                 RaiseLocalEvent(uid, ref modEv);
-
 
                 TryUpdateResourcesAmount(uid, resourceData, modEv.Modifier, resourcesComp);
 
@@ -329,6 +325,6 @@ public abstract class SharedInternalResourcesSystem : EntitySystem
             if (dirtyNeeded)
                 Dirty(uid, resourcesComp);
         }
-        // СorvaxGoob edit end
-}
+        // CorvaxGoob edit end
+    }
 }

--- a/Content.Shared/_CorvaxGoob/InternalResources/Data/ThresholdData.cs
+++ b/Content.Shared/_CorvaxGoob/InternalResources/Data/ThresholdData.cs
@@ -1,7 +1,6 @@
-// CorvaxGoob
 using Robust.Shared.Serialization;
 
-namespace Content.Goobstation.Shared.InternalResources.Data;
+namespace Content.Shared._CorvaxGoob.InternalResources.Data;
 
 [Serializable, NetSerializable]
 [DataDefinition]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Ko4ergaPunk <nikitako4erga3i5@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Оптимизация SharedInternalResourcesSystem.Update. Устранение лишних аллокаций памяти и вызовов Dirty.

## Почему / Баланс
Система SharedInternalResourcesSystem запускается раз в секунду и итерирует все сущности с InternalResourcesComponent (генокрад, тенеморф, фантом и тд).
Thresholds.Keys.ToArray() создавал новый массив на каждую сущность с порогами.
Dirty(uid, resourcesComp) вызывался внутри foreach по ресурсам даже если ничего не изменилось (regen = 0, пороги не изменились), и дублировал вызов из TryUpdateResourcesAmount.

## Технические детали
1)Новый класс ThresholdData (Content.Goobstation.Shared/InternalResources/Data/ThresholdData.cs
Заменяет value-tuple (float, bool) в Thresholds. Поскольку ThresholdData это reference type, модификация поля threshold.Met внутри foreach (var (key, threshold) in dict) не инкрементирует _version словаря, это позволяет безопасно итерировать без .ToArray().
2) Изменение типа Thresholds в InternalResourcesData.cs и InternalResourcesThresholdsPrototype.cs
Dictionary<string, (float, bool)>? -> Dictionary<string, ThresholdData>?
3) Правки в Update в SharedInternalResourcesSystem.cs
Убран Keys.ToArray() потому что итерация напрямую через foreach (var (key, threshold) in resourceData.Thresholds).
Убран двойной поиск в словаре (Thresholds[key] read + write).
Убран  Dirty без условий внутри foreach по ресурсам.
Добавлен флаг dirtyNeeded на уровне сущности. Так Dirty вызывается один раз после всех ресурсов, только если состояние порога реально изменилось
4) Удалён неиспользуемый using System.Linq из SharedInternalResourcesSystem.cs.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
Изменён тип поля InternalResourcesData.Thresholds и InternalResourcesThresholdsPrototype.Thresholds.
Dictionary<string, (float, bool)>? -> Dictionary<string, ThresholdData>?

**Список изменений**
:cl: RomaGur
- tweak: Оптимизирована система внутренних ресурсов.

