### PR TITLE
Feroxi fix

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
@@ -202,3 +202,28 @@
       sprite: "_DV/Effects/creampie.rsi"
       state: "creampie_feroxi"
       visible: false
+  - type: Inventory # Goob-Feroxi-Resprite-Start
+    speciesId: feroxi
+    femaleDisplacements:
+      jumpsuit:
+        sizeMaps:
+          32:
+            sprite: _White/Mobs/Species/displacement.rsi
+            state: jumpsuit-female
+      shoes:
+        sizeMaps:
+          32:
+            sprite: _White/Mobs/Species/displacement.rsi
+            state: shoes
+    displacements:
+      jumpsuit:
+        sizeMaps:
+          32:
+            sprite: _White/Mobs/Species/displacement.rsi
+            state: jumpsuit
+      shoes:
+        sizeMaps:
+          32:
+            sprite: _White/Mobs/Species/displacement.rsi
+            state: shoes
+    # Goob-Feroxi-Resprite-End

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
@@ -202,7 +202,7 @@
       sprite: "_DV/Effects/creampie.rsi"
       state: "creampie_feroxi"
       visible: false
-  - type: Inventory # Goob-Feroxi-Resprite-Start
+  - type: Inventory # CorvaxGoob-Feroxi-Resprite-Start
     speciesId: feroxi
     femaleDisplacements:
       jumpsuit:
@@ -226,4 +226,4 @@
           32:
             sprite: _White/Mobs/Species/displacement.rsi
             state: shoes
-    # Goob-Feroxi-Resprite-End
+    # CorvaxGoob-Feroxi-Resprite-End


### PR DESCRIPTION
## Описание PR
Йо. я вспомнил что я забыл. Короче теперь ферокси норм отображаются в лобби.

## Медиа
было
<img width="128" height="115" alt="image" src="https://github.com/user-attachments/assets/d0779544-1c04-4ccc-9d86-461efd3f77a9" />
Стало
<img width="231" height="324" alt="Screenshot 2026-05-10 152006" src="https://github.com/user-attachments/assets/44fda3f0-da8d-4ac7-a89e-eaa5f1b1781f" />
Короче да.

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl: RedTerror
- fix: Ферокси теперь коректно отображаются в лобби

