### PR TITLE
Уменьшен размер портсигару

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/case.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/case.yml
@@ -102,7 +102,7 @@
     - 0,0,3,1
   - type: Item
     sprite: Objects/Consumable/Smokeables/Cigars/case.rsi
-    size: Small # CorvaxGoob
+    size: Small # CorvaxGoob: Normal --> Small
     shape:
     - 0,0,2,1
     storedRotation: 90

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/case.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/case.yml
@@ -102,7 +102,7 @@
     - 0,0,3,1
   - type: Item
     sprite: Objects/Consumable/Smokeables/Cigars/case.rsi
-    size: Normal
+    size: Small # CorvaxGoob
     shape:
     - 0,0,2,1
     storedRotation: 90

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/case.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/case.yml
@@ -102,7 +102,7 @@
     - 0,0,3,1
   - type: Item
     sprite: Objects/Consumable/Smokeables/Cigars/case.rsi
-    size: Small # CorvaxGoob: Normal --> Small
+    size: Small #CorvaxGoob: Normal --> Small
     shape:
     - 0,0,2,1
     storedRotation: 90


### PR DESCRIPTION
## Описание PR
- Уменьшен размер портсигару до маленького

## Почему / Баланс
Из-за своего размера не помещается в карманы куртки, что я считаю бредом.
Та же самая коробка с пончиками имеет малый размер, а она уж гораздо больше чем портсигар.

## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

**Список изменений**
:cl: drunkmaster-dev:
- fix: Уменьшен размер портсигару до маленького