### PR TITLE
Патроны-фальшфейеры теперь можно печатать на ОхранФабе

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -28,6 +28,7 @@
   id: SecurityPracticeStatic
   recipes:
   - BoxShotgunPractice
+  - BoxShotgunFlare #CorvaxGoob: add box
   # - MagazineBoxLightRiflePractice # Goobstation - remove light rifle
   - MagazineBoxMagnumPractice
   - MagazineBoxPistolPractice


### PR DESCRIPTION
## Описание PR
- Патроны-фальшфейеры теперь можно печатать на ОхранФабе

## Почему / Баланс
Предложение/Идея: https://discord.com/channels/919301044784226385/1506321880544448562
## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

**Список изменений**
:cl: drunkmaster-dev:
- add: Патроны-фальшфейеры теперь можно печатать на ОхранФабе