### PR TITLE
Вернуть старый формат настенных таймеров

### DIFF
--- a/Content.Client/MachineLinking/UI/SignalTimerBoundUserInterface.cs
+++ b/Content.Client/MachineLinking/UI/SignalTimerBoundUserInterface.cs
@@ -30,7 +30,9 @@ public sealed class SignalTimerBoundUserInterface : BoundUserInterface
         _window = this.CreateWindow<SignalTimerWindow>();
         _window.OnStartTimer += StartTimer;
         _window.OnCurrentTextChanged += OnTextChanged;
-        _window.OnCurrentDelayChanged += OnDelayChanged; // Mono
+        // _window.OnCurrentDelayChanged += OnDelayChanged; // Mono // CorvaxGoob-Revert
+        _window.OnCurrentDelayMinutesChanged += OnDelayChanged; // CorvaxGoob-Revert
+        _window.OnCurrentDelaySecondsChanged += OnDelayChanged; // CorvaxGoob-Revert
     }
 
     public void StartTimer()
@@ -43,11 +45,11 @@ public sealed class SignalTimerBoundUserInterface : BoundUserInterface
         SendMessage(new SignalTimerTextChangedMessage(newText));
     }
 
-    private void OnDelayChanged(TimeSpan newDelay) // Mono
+    private void OnDelayChanged(string newDelay) // CorvaxGoob-Revert
     {
         if (_window == null)
             return;
-        SendMessage(new SignalTimerDelayChangedMessage(newDelay)); // Mono
+        SendMessage(new SignalTimerDelayChangedMessage(_window.GetDelay())); // CorvaxGoob-Revert
     }
 
     /// <summary>
@@ -62,7 +64,9 @@ public sealed class SignalTimerBoundUserInterface : BoundUserInterface
             return;
 
         _window.SetCurrentText(cast.CurrentText);
-        _window.SetCurrentDelay(cast.CurrentDelay); // Mono
+        // _window.SetCurrentDelay(cast.CurrentDelay); // Mono // CorvaxGoob-Revert
+        _window.SetCurrentDelayMinutes(cast.CurrentDelayMinutes); // CorvaxGoob-Revert
+        _window.SetCurrentDelaySeconds(cast.CurrentDelaySeconds); // CorvaxGoob-Revert
         _window.SetShowText(cast.ShowText);
         _window.SetTriggerTime(cast.TriggerTime);
         _window.SetTimerStarted(cast.TimerStarted);

--- a/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml
+++ b/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml
@@ -7,16 +7,19 @@ SPDX-License-Identifier: MIT
 
 <DefaultWindow xmlns="https://spacestation14.io"
             Title="{Loc signal-timer-menu-title}">
-    <BoxContainer Orientation="Vertical" SeparationOverride="4" MinSize="200 100"> <!-- Goob: changed to MinSize instead of MinWidth -->
+    <BoxContainer Orientation="Vertical" SeparationOverride="4" MinWidth="150"> <!--CorvaxGoob-Revert-->
         <BoxContainer Name="TextEdit" Orientation="Horizontal">
             <Label Name="CurrentLabel" Text="{Loc signal-timer-menu-label}" />
-            <LineEdit Name="CurrentTextEdit" MinWidth="160" /> <!-- Goob: increased MinWidth -->
+            <LineEdit Name="CurrentTextEdit" MinWidth="80" /> <!--CorvaxGoob-Revert-->
         </BoxContainer>
         <BoxContainer Name="DelayEdit" Orientation="Horizontal">
             <Label Name="CurrentDelay" Text="{Loc signal-timer-menu-delay}" />
-            <!-- Mono: Changed from integer MM:SS to float seconds -->
-            <FloatSpinBox Name="CurrentDelayEdit" MinWidth="160" /> <!-- Goob: increased MinWidth -->
-            <Label Text="s" />
+            <!--CorvaxGoob-Revert-Start-->
+            <LineEdit Name="CurrentDelayEditMinutes" MinWidth="32" />
+            <Label Name="Colon" Text=":" />
+            <LineEdit Name="CurrentDelayEditSeconds" MinWidth="32" />
+            <Label Name="DelayInfo" Text=" (mm:ss)" />
+            <!--CorvaxGoob-Revert-End-->
         </BoxContainer>
         <Button Name="StartTimer" Text="{Loc signal-timer-menu-start}" />
     </BoxContainer>

--- a/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml.cs
+++ b/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml.cs
@@ -57,7 +57,9 @@ public sealed partial class SignalTimerWindow : DefaultWindow
     private const int MaxTextLength = 5;
 
     public event Action<string>? OnCurrentTextChanged;
-    public event Action<TimeSpan>? OnCurrentDelayChanged; // Mono
+    // public event Action<TimeSpan>? OnCurrentDelayChanged; // Mono // CorvaxGoob-Revert
+    public event Action<string>? OnCurrentDelayMinutesChanged; // CorvaxGoob-Revert
+    public event Action<string>? OnCurrentDelaySecondsChanged; // CorvaxGoob-Revert
 
     private TimeSpan? _triggerTime;
 
@@ -71,7 +73,9 @@ public sealed partial class SignalTimerWindow : DefaultWindow
         IoCManager.InjectDependencies(this);
 
         CurrentTextEdit.OnTextChanged += e => OnCurrentTextChange(e.Text);
-        CurrentDelayEdit.OnValueChanged += e => CurrentDelayChange(TimeSpan.FromSeconds(e.Value)); // Mono
+        // CurrentDelayEdit.OnValueChanged += e => CurrentDelayChange(TimeSpan.FromSeconds(e.Value)); // Mono // CorvaxGoob-Revert
+        CurrentDelayEditMinutes.OnTextChanged += e => OnCurrentDelayMinutesChange(e.Text); // CorvaxGoob-Revert
+        CurrentDelayEditSeconds.OnTextChanged += e => OnCurrentDelaySecondsChange(e.Text); // CorvaxGoob-Revert
         StartTimer.OnPressed += _ => StartTimerWeh();
     }
 
@@ -117,22 +121,84 @@ public sealed partial class SignalTimerWindow : DefaultWindow
         OnCurrentTextChanged?.Invoke(text);
     }
 
-    // Mono
-    public void CurrentDelayChange(TimeSpan newValue)
+    // CorvaxGoob-Revert-Start
+    public void OnCurrentDelayMinutesChange(string text)
     {
-        OnCurrentDelayChanged?.Invoke(newValue);
+        List<char> toRemove = new();
+
+        foreach (var a in text)
+        {
+            if (!char.IsDigit(a))
+                toRemove.Add(a);
+        }
+
+        foreach (var a in toRemove)
+        {
+            CurrentDelayEditMinutes.Text = text.Replace(a.ToString(), "");
+        }
+
+        if (CurrentDelayEditMinutes.Text == "")
+            return;
+
+        while (CurrentDelayEditMinutes.Text[0] == '0' && CurrentDelayEditMinutes.Text.Length > 2)
+        {
+            CurrentDelayEditMinutes.Text = CurrentDelayEditMinutes.Text.Remove(0, 1);
+        }
+
+        if (CurrentDelayEditMinutes.Text.Length > 2)
+        {
+            CurrentDelayEditMinutes.Text = CurrentDelayEditMinutes.Text.Remove(2);
+        }
+        OnCurrentDelayMinutesChanged?.Invoke(CurrentDelayEditMinutes.Text);
     }
+
+    public void OnCurrentDelaySecondsChange(string text)
+    {
+        List<char> toRemove = new();
+
+        foreach (var a in text)
+        {
+            if (!char.IsDigit(a))
+                toRemove.Add(a);
+        }
+
+        foreach (var a in toRemove)
+        {
+            CurrentDelayEditSeconds.Text = text.Replace(a.ToString(), "");
+        }
+
+        if (CurrentDelayEditSeconds.Text == "")
+            return;
+
+        while (CurrentDelayEditSeconds.Text[0] == '0' && CurrentDelayEditSeconds.Text.Length > 2)
+        {
+            CurrentDelayEditSeconds.Text = CurrentDelayEditSeconds.Text.Remove(0, 1);
+        }
+
+        if (CurrentDelayEditSeconds.Text.Length > 2)
+        {
+            CurrentDelayEditSeconds.Text = CurrentDelayEditSeconds.Text.Remove(2);
+        }
+        OnCurrentDelaySecondsChanged?.Invoke(CurrentDelayEditSeconds.Text);
+    }
+    // CorvaxGoob-Revert-End
 
     public void SetCurrentText(string text)
     {
         CurrentTextEdit.Text = text;
     }
 
-    // Mono
-    public void SetCurrentDelay(TimeSpan delay)
+    // CorvaxGoob-Revert-Start
+    public void SetCurrentDelayMinutes(string delay)
     {
-        CurrentDelayEdit.Value = (float)delay.TotalSeconds;
+        CurrentDelayEditMinutes.Text = delay;
     }
+
+    public void SetCurrentDelaySeconds(string delay)
+    {
+        CurrentDelayEditSeconds.Text = delay;
+    }
+    // CorvaxGoob-Revert-End
 
     public void SetShowText(bool showTime)
     {
@@ -158,6 +224,8 @@ public sealed partial class SignalTimerWindow : DefaultWindow
     public void SetHasAccess(bool hasAccess)
     {
         CurrentTextEdit.Editable = hasAccess;
+        CurrentDelayEditMinutes.Editable = hasAccess; // CorvaxGoob-Revert
+        CurrentDelayEditSeconds.Editable = hasAccess; // CorvaxGoob-Revert
         StartTimer.Disabled = !hasAccess;
     }
 
@@ -166,6 +234,12 @@ public sealed partial class SignalTimerWindow : DefaultWindow
     /// </summary>
     public TimeSpan GetDelay()
     {
-        return TimeSpan.FromSeconds(CurrentDelayEdit.Value); // Mono
+        // CorvaxGoob-Revert-Start
+        if (!double.TryParse(CurrentDelayEditMinutes.Text, out var minutes))
+            minutes = 0;
+        if (!double.TryParse(CurrentDelayEditSeconds.Text, out var seconds))
+            seconds = 0;
+        return TimeSpan.FromMinutes(minutes) + TimeSpan.FromSeconds(seconds);
+        // CorvaxGoob-Revert-End
     }
 }

--- a/Content.Server/DeviceLinking/Systems/SignalTimerSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/SignalTimerSystem.cs
@@ -70,7 +70,9 @@ public sealed class SignalTimerSystem : EntitySystem
         if (_ui.HasUi(uid, SignalTimerUiKey.Key))
         {
             _ui.SetUiState(uid, SignalTimerUiKey.Key, new SignalTimerBoundUserInterfaceState(component.Label,
-                TimeSpan.FromSeconds(component.Delay), // Mono
+                // TimeSpan.FromSeconds(component.Delay), // Mono // CorvaxGoob-Revert-Start
+                TimeSpan.FromSeconds(component.Delay).Minutes.ToString("D2"),
+                TimeSpan.FromSeconds(component.Delay).Seconds.ToString("D2"), // CorvaxGoob-Revert-End
                 component.CanEditLabel,
                 time,
                 active != null,
@@ -91,7 +93,9 @@ public sealed class SignalTimerSystem : EntitySystem
         if (_ui.HasUi(uid, SignalTimerUiKey.Key))
         {
             _ui.SetUiState(uid, SignalTimerUiKey.Key, new SignalTimerBoundUserInterfaceState(signalTimer.Label,
-                TimeSpan.FromSeconds(signalTimer.Delay), // Mono
+                // TimeSpan.FromSeconds(signalTimer.Delay), // Mono // CorvaxGoob-Revert-Start
+                TimeSpan.FromSeconds(signalTimer.Delay).Minutes.ToString("D2"),
+                TimeSpan.FromSeconds(signalTimer.Delay).Seconds.ToString("D2"), // CorvaxGoob-Revert-End
                 signalTimer.CanEditLabel,
                 TimeSpan.Zero,
                 false,

--- a/Content.Shared/MachineLinking/SharedSignalTimerComponent.cs
+++ b/Content.Shared/MachineLinking/SharedSignalTimerComponent.cs
@@ -22,21 +22,27 @@ public enum SignalTimerUiKey : byte
 public sealed class SignalTimerBoundUserInterfaceState : BoundUserInterfaceState
 {
     public string CurrentText;
-    public TimeSpan CurrentDelay; // Mono
+    // public TimeSpan CurrentDelay; // Mono // CorvaxGoob-Revert-Start
+    public string CurrentDelayMinutes;
+    public string CurrentDelaySeconds; // CorvaxGoob-Revert-End
     public bool ShowText;
     public TimeSpan TriggerTime;
     public bool TimerStarted;
     public bool HasAccess;
 
     public SignalTimerBoundUserInterfaceState(string currentText,
-        TimeSpan currentDelay, // Mono
+        // TimeSpan currentDelay, // Mono // CorvaxGoob-Revert-Start
+        string currentDelayMinutes,
+        string currentDelaySeconds, // CorvaxGoob-Revert-End
         bool showText,
         TimeSpan triggerTime,
         bool timerStarted,
         bool hasAccess)
     {
         CurrentText = currentText;
-        CurrentDelay = currentDelay; // Mono
+        // CurrentDelay = currentDelay; // Mono // CorvaxGoob-Revert-Start
+        CurrentDelayMinutes = currentDelayMinutes;
+        CurrentDelaySeconds = currentDelaySeconds; // CorvaxGoob-Revert-End
         ShowText = showText;
         TriggerTime = triggerTime;
         TimerStarted = timerStarted;


### PR DESCRIPTION
## Описание PR
Вернут старый формат настенных таймеров

## Почему / Баланс
Удобно для СБ, которому нужно минуты в секунды переводить.

В идеале нужно сделать две версии UI: для СБ и для делающих механизмы

## Медиа
<img width="321" height="187" alt="image" src="https://github.com/user-attachments/assets/55467ac0-469f-4ab8-a0c6-f4e13777c249" />

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl: KillanGenifer
- tweak: Вернут старый формат настенных таймеров
