### PR TITLE
little patchfix-30-05

### DIFF
--- a/Content.Shared/UserInterface/ActivatableUISystem.cs
+++ b/Content.Shared/UserInterface/ActivatableUISystem.cs
@@ -300,12 +300,15 @@ public sealed partial class ActivatableUISystem : EntitySystem
 
         // If we've gotten this far, fire a cancellable event that indicates someone is about to activate this.
         // This is so that stuff can require further conditions (like power).
-        var oae = new ActivatableUIOpenAttemptEvent(user);
-        var uae = new UserOpenActivatableUIAttemptEvent(user, uiEntity);
-        RaiseLocalEvent(user, uae);
-        RaiseLocalEvent(uiEntity, oae);
-        if (oae.Cancelled || uae.Cancelled)
-            return false;
+        if (ghost is null) // CorvaxGoob-GhostUIViewing : Убирает какие-либо илзишнее проверки для гостов
+        {
+            var oae = new ActivatableUIOpenAttemptEvent(user);
+            var uae = new UserOpenActivatableUIAttemptEvent(user, uiEntity);
+            RaiseLocalEvent(user, uae);
+            RaiseLocalEvent(uiEntity, oae);
+            if (oae.Cancelled || uae.Cancelled)
+                return false;
+        }
 
         // Give the UI an opportunity to prepare itself if it needs to do anything
         // before opening

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -140,6 +140,8 @@
     damage:
       types:
         Blunt: 10
+    soundHit: # CorvaxGoob
+      path: /Audio/Weapons/Guns/Hits/snap.ogg
   - type: StaminaDamageModifierOnCollide # CorvaxGoob
     staminaCoefficient: 5
   # - type: StaminaDamageOnCollide # Commented by CorvaxGoob

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -127,7 +127,7 @@
     CaptainJetpackStealObjective: 0.5
     HandTeleporterStealObjective: 0.5
     EnergyShotgunStealObjective: 0.5
-    StealSupermatterSliverObjective: 0.5 # Goobstation - supermatter
+    # StealSupermatterSliverObjective: 0.5 # Goobstation - supermatter # CorvaxGoob-Balance
     LawbringerStealObjective: 0.5 # Goobstation
     GeminiProjectorStealObjective: 0.5 # Goobstation
     ExecutiveBriefcaseStealObjective: 0.5 # Goobstation

--- a/Resources/Prototypes/Recipes/Lathes/mech_parts.yml
+++ b/Resources/Prototypes/Recipes/Lathes/mech_parts.yml
@@ -57,6 +57,9 @@
   result: RipleyHarness
   categories:
   - Ripley # Goobstation
+  materials: # CorvaxGoob-Fix
+    Steel: 1200
+    Glass: 1000
 
 - type: latheRecipe
   parent: BaseRipleyLimbRecipe


### PR DESCRIPTION
:cl: KillanGenifer
- tweak: Госты могут просматривать любые интерфейсы в обход любых проверок (например наличия питания).
- tweak: Травматические пули .50 калибра при попадании получили такой же звук как и остальных таких же патрон.
- remove: Удалена цель для агентов на кражу суперматерии.
- fix: Исправлен пустой рецепт каркаса рипли из омнилата.
