### PR TITLE
Revert "Increase shotguns capacity"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -103,7 +103,7 @@
     whitelist:
       tags:
       - ShellShotgun
-    capacity: 8
+    capacity: 7
     proto: ShellShotgun
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/shotgun_insert.ogg


### PR DESCRIPTION
## Описание PR  
Откатил изменений размера магазина дробовиков( https://github.com/space-syndicate/Goob-Station/pull/875).
  
## Почему / Баланс  
Продали баланс за 300 рублей. Каждый патрон на дробовике решает перестрелку, потому что их всего там 7 изначально. Усиливать например силовик ради эстетического удовольствия дело сомнительное(силовик и так силен, куда еще больше).
Если очень нужно могу чуть позже сделать пр, чтобы в коробке и в барабане было по 14 и 7 патронов соответственно.
А еще меня попросили этот ПР открыть.
## Требования  
<!-- Подтвердите следующее, поставив X в скобках [X]: -->  
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).  
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.  