### PR TITLE
Малютка PatchFix

### DIFF
--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -103,7 +103,9 @@ using Content.Goobstation.Common.Grab;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Alert;
+using Content.Shared.Bed.Sleep; // CorvaxGoob
 using Content.Shared.Buckle.Components;
+using Content.Shared.Damage.Components; // CorvaxGoob
 using Content.Shared.CombatMode;
 using Content.Shared.Cuffs;
 using Content.Shared.Cuffs.Components;
@@ -157,6 +159,7 @@ public sealed class PullingSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedVirtualItemSystem _virtualSystem = default!;
     [Dependency] private readonly SharedCombatModeSystem _combatMode = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!; // CorvaxGoob
 
     public override void Initialize()
     {
@@ -748,6 +751,14 @@ public sealed class PullingSystem : EntitySystem
         // Goobstation - Grab Intent
         if (!ignoreGrab)
         {
+            // CorvaxGoob start
+            if (user == pullableUid
+                && (_mobState.IsIncapacitated(pullableUid)
+                    || HasComp<SleepingComponent>(pullableUid)
+                    || (TryComp<StaminaComponent>(pullableUid, out var stamina) && stamina.Critical)))
+                return false;
+            // CorvaxGoob end
+
             var tryReleaseEv = new GrabAttemptReleaseEvent(user, pullerUidNull.Value);
             RaiseLocalEvent(pullableUid, ref tryReleaseEv);
             if (!tryReleaseEv.Released)

--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -163,6 +163,7 @@
     sprite: Clothing/Head/Hardsuits/paramedhelm.rsi #corvaxGoob
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/paramedhelm.rsi #corvaxGoob
+    equippedState: off-equipped-head # CorvaxGoob
   - type: PointLight # goobstation
     color: "#3385cc"
   - type: TemperatureProtection

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -216,7 +216,7 @@
     #gloves: ClothingHandsGlovesHop
     ears: ClothingHeadsetAltCommand
     belt: BoxFolderClipboard
-    eyes: ClothingEyesHudCommand
+    #eyes: ClothingEyesHudCommand CorvaxGoob
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/tajaran.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/tajaran.yml
@@ -110,7 +110,7 @@
   - type: TypingIndicator
     proto: felinid
   - type: Inventory
-    speciesId: reptilian # whyyy
+    #speciesId: reptilian # whyyy CorvaxGoob
     femaleDisplacements:
       jumpsuit:
         sizeMaps:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Ko4ergaPunk <nikitako4erga3i5@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
<!-- Что вы изменили? -->
Исправлен баг с отображением волос в скафандре парамедика.
Исправлен баг с отображением второго хвоста в некоторых скафандрах у таяр.
Исправлен баг с возможностью выбраться из граба/пулла в сне, стамина-крите, в мертвом, крит состоянии.
У гп теперь нет раундстарт визора. Необходимо выбирать в лодауте.
## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
У скафандра парамедика теперь используется `off-euipped-head`
Закомментирована строка у таяр `speciesId: reptilian`
Закомментирована строка у ГП `eyes: ClothingEyesHudCommand`
Добавлено дополнительное условие в `PullingSystem`
## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
До 
<img width="170" height="228" alt="image" src="https://github.com/user-attachments/assets/022be769-5894-47af-b19a-fa4c99beb989" />
После
<img width="270" height="278" alt="image" src="https://github.com/user-attachments/assets/bd6b09d2-a8b6-4a43-bfbb-52622751f867" />
До
<img width="142" height="135" alt="image" src="https://github.com/user-attachments/assets/07eed758-48b5-4264-ae1c-14178fdeca21" />
После
<img width="283" height="246" alt="image" src="https://github.com/user-attachments/assets/35e9c220-a590-4df0-be60-3e1127c445b8" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- fix: Исправлен баг с отображением волос в скафандре парамедика.
- fix: Исправлен баг с отображением второго хвоста в некоторых скафандрах у таяр.
- fix: Исправлен баг с возможностью выбраться из граба/пулла в сне, стамина-крите, в мертвом, крит состоянии.
- tweak: У ГП теперь нет раундстарт визора. 

