### PR TITLE
Удар прикладом для всех оружий

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -193,6 +193,17 @@
     missChance: 0.4
     spreadMultiplier: 3
     spreadAddition: 40
+  #CorvaxGoob: commit, because already have parent
+  #- type: AltFireMelee # Goobstation V
+  # attackType: Heavy
+  #- type: MeleeWeapon
+  #  damage:
+  #    types:
+  #     Blunt: 12
+  #  angle: 0
+  #  wideAnimationRotation: 90 # -90 if it takes bayonets (hits with muzzle) 90 if not (hits with butt)
+  #  soundHit:
+  #   collection: MetalThud # Goobstation ^
 
 - type: entity
   id: BaseWeaponPowerCell

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -146,7 +146,7 @@
 
 - type: entity
   id: BaseWeaponBattery
-  parent: BaseItem
+  parent: [BaseItem, BaseButtStroke] #CorvaxGoob: add ButtStroke parent
   abstract: true
   components:
   - type: Sprite
@@ -187,15 +187,6 @@
     sound:
       collection: LasersDrop
   # Goobstation edit end
-  - type: AlwaysHot # Goobstation V
-  - type: MeleeWeapon
-    damage:
-      types:
-       Blunt: 12
-    angle: 0
-    wideAnimationRotation: 90 # -90 if it takes bayonets (hits with muzzle) 90 if not (hits with butt)
-    soundHit:
-      collection: MetalThud # Goobstation ^
   - type: BatteryDrinkerSource # Goobstation - Energycrit
     maxAmount: 180 # you probably don't want to drain your entire gun charging in battle
   - type: Multishot # Goobstation V

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -90,7 +90,7 @@
 
 - type: entity
   name: BaseWeaponHeavyMachineGun
-  parent: BaseItem
+  parent: [BaseItem, BaseButtStroke] #CorvaxGoob: add ButtStroke parent
   id: BaseWeaponHeavyMachineGun
   description: Spray and pray.
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -51,7 +51,7 @@
 
 - type: entity
   name: BaseWeaponLightMachineGun
-  parent: BaseItem
+  parent: [BaseItem, BaseButtStroke] #CorvaxGoob: add ButtStroke parent
   id: BaseWeaponLightMachineGun
   description: A rooty tooty point and shooty.
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -160,6 +160,17 @@
     sound:
       collection: RiflesDrop
   # Goobstation edit end
+  #CorvaxGoob: commit, because already have parent
+  #- type: AltFireMelee # Goobstation V
+  # attackType: Heavy
+  #- type: MeleeWeapon
+  #  damage:
+  #    types:
+  #     Blunt: 12
+  #  angle: 0
+  #  wideAnimationRotation: 90 # -90 if it takes bayonets (hits with muzzle) 90 if not (hits with butt)
+  #  soundHit:
+  #   collection: MetalThud # Goobstation ^
 
 - type: entity
   name: AKM

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -84,7 +84,7 @@
 
 - type: entity
   name: BaseWeaponRifle
-  parent: [BaseItem, BaseGunWieldable]
+  parent: [BaseItem, BaseGunWieldable, BaseButtStroke] #CorvaxGoob: add ButtStroke parent
   id: BaseWeaponRifle
   description: A rooty tooty point and shooty.
   abstract: true
@@ -142,16 +142,6 @@
     missChance: 0.4
     spreadMultiplier: 3
     spreadAddition: 60 #youre not multifiring a rifle
-  - type: AltFireMelee
-    attackType: Heavy
-  - type: MeleeWeapon
-    damage:
-      types:
-       Blunt: 12
-    angle: 0
-    wideAnimationRotation: 90 # -90 if it takes bayonets (hits with muzzle) 90 if not (hits with butt)
-    soundHit:
-      collection: MetalThud # Goobstation ^
   # Goobstation edit start
   - type: EmitSoundOnPickup
     sound:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -145,6 +145,17 @@
     missChance: 0.4
     spreadMultiplier: 3
     spreadAddition: 50 #very hard to hold two of these steady let alone steady while shooting them
+  #CorvaxGoob: commit, because already have parent
+  #- type: AltFireMelee # Goobstation V
+  # attackType: Heavy
+  #- type: MeleeWeapon
+  #  damage:
+  #    types:
+  #     Blunt: 12
+  #  angle: 0
+  #  wideAnimationRotation: 90 # -90 if it takes bayonets (hits with muzzle) 90 if not (hits with butt)
+  #  soundHit:
+  #   collection: MetalThud # Goobstation ^
 
 - type: entity
   name: Atreides

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -65,7 +65,7 @@
 
 - type: entity
   name: BaseSMG
-  parent: BaseItem
+  parent: [BaseItem, BaseButtStroke] #CorvaxGoob: add ButtStroke parent
   id: BaseWeaponSubMachineGun
   description: A rooty tooty point and shooty.
   abstract: true
@@ -145,16 +145,6 @@
     missChance: 0.4
     spreadMultiplier: 3
     spreadAddition: 50 #very hard to hold two of these steady let alone steady while shooting them
-  - type: AltFireMelee
-    attackType: Heavy
-  - type: MeleeWeapon
-    damage:
-      types:
-       Blunt: 10 # lower melee damage for SMGs as they are lighter
-    angle: 0
-    wideAnimationRotation: 90 # -90 if it takes bayonets (hits with muzzle) 90 if not (hits with butt)
-    soundHit:
-      collection: MetalThud # Goobstation ^
 
 - type: entity
   name: Atreides

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -71,7 +71,7 @@
 
 - type: entity
   name: BaseWeaponShotgun
-  parent: BaseItem
+  parent: [BaseItem, BaseButtStroke] #CorvaxGoob: add ButtStroke parent
   id: BaseWeaponShotgun
   description: A rooty tooty point and shooty.
   abstract: true
@@ -135,16 +135,6 @@
     - oni-cannot-shoot-guns-2
     - oni-cannot-shoot-guns-3
   # Goobstation edit end
-  - type: AltFireMelee # Goobstation V
-    attackType: Heavy
-  - type: MeleeWeapon
-    damage:
-      types:
-       Blunt: 12
-    angle: 0
-    wideAnimationRotation: 90 # -90 if it takes bayonets (hits with muzzle) 90 if not (hits with butt)
-    soundHit:
-      collection: MetalThud # Goobstation ^
 
 - type: entity
   name: Bulldog

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -135,6 +135,17 @@
     - oni-cannot-shoot-guns-2
     - oni-cannot-shoot-guns-3
   # Goobstation edit end
+  #CorvaxGoob: commit, because already have parent
+  #- type: AltFireMelee # Goobstation V
+  # attackType: Heavy
+  #- type: MeleeWeapon
+  #  damage:
+  #    types:
+  #     Blunt: 12
+  #  angle: 0
+  #  wideAnimationRotation: 90 # -90 if it takes bayonets (hits with muzzle) 90 if not (hits with butt)
+  #  soundHit:
+  #   collection: MetalThud # Goobstation ^
 
 - type: entity
   name: Bulldog

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -316,6 +316,17 @@
   # soundHit:
   #   path: /Audio/Weapons/bladeslice.ogg
   - type: GunRequiresWield
+  #CorvaxGoob: commit, because already have parent
+  #- type: AltFireMelee # Goobstation V
+  # attackType: Heavy
+  #- type: MeleeWeapon
+  #  damage:
+  #    types:
+  #     Blunt: 12
+  #  angle: 0
+  #  wideAnimationRotation: 90 # -90 if it takes bayonets (hits with muzzle) 90 if not (hits with butt)
+  #  soundHit:
+  #   collection: MetalThud # Goobstation ^
 
 - type: entity
   name: flintlock pistol

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -69,7 +69,7 @@
 
 - type: entity
   name: BaseWeaponSniper
-  parent: BaseItem
+  parent: [BaseItem, BaseButtStroke] #CorvaxGoob: add ButtStroke parent
   id: BaseWeaponSniper
   description: A rooty tooty point and shooty.
   abstract: true
@@ -119,14 +119,6 @@
     sound:
       collection: SnipersDrop
   # Goobstation edit end
-  - type: MeleeWeapon # Goobstation V
-    damage:
-      types:
-       Blunt: 12
-    angle: 0
-    wideAnimationRotation: 90 # -90 if it takes bayonets (hits with muzzle) 90 if not (hits with butt)
-    soundHit:
-      collection: MetalThud # Goobstation ^
 
 # Goobstation - Start - I decided to put it here, because it changes Hristov.
 - type: entity

--- a/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Weapons/Guns/Basic/base_butt_stroke.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Weapons/Guns/Basic/base_butt_stroke.yml
@@ -1,0 +1,14 @@
+- type: entity
+  id: BaseButtStroke
+  abstract: true
+  components: 
+  - type: AltFireMelee
+    attackType: Heavy
+  - type: MeleeWeapon
+    damage:
+      types:
+       Blunt: 12
+    angle: 0
+    wideAnimationRotation: 90
+    soundHit:
+      collection: MetalThud


### PR DESCRIPTION
## Описание PR
- Создан и добавлен parent всем крупным оружиям, который позволяет им атаковать прикладом.

## Почему / Баланс
Предложение/Идея: https://discord.com/channels/919301044784226385/1511417572774645770
P.S Изначально планировалось как багфикс, но я решил что стоит ещё добавить некоторым оружиям возможность атаки.

## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

**Список изменений**
:cl: drunkmaster-dev:
- add: Создан и добавлен parent всем крупным оружиям, который позволяет им атаковать прикладом.