### PR TITLE
Фикс БС Транзита

### DIFF
--- a/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Power/substations.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Power/substations.yml
@@ -11,7 +11,7 @@
     maxChargeRate: 5000000000
     supplyRampTolerance: 1000
     supplyRampRate: 1000000000
-    efficiency: 100
+    efficiency: 1
   - type: BatteryInterface
     maxChargeRate: 5000000000
     maxSupply: 3000000000


### PR DESCRIPTION
## Описание PR
Блюспейс Т.Р.А.Н.З.И.Т. больше не работает с 100х эффективностью. Теперь если он передаёт 1мвт, он будет потреблять 1мвт а не 10квт

## Почему / Баланс
Никогда не задумывалось умножение. Теперь инженерам надо запрягаться ради него, никаких подпольных БСХ на бананиуме. Вообще могут, но не на 10м уровне

## Технические детали
One liner

## Медиа
<img width="1191" height="756" alt="изображение" src="https://github.com/user-attachments/assets/40685c48-6330-478b-8c2a-5540caea4e7a" />


## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

**Список изменений**
:cl: Elusive
- fix: Блюспейс Т.Р.А.Н.З.И.Т. больше не умножает энергию в 100 раз
