### PR TITLE
Адский чемодан

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
@@ -59,6 +59,7 @@
     ClothingHeadHatFedoraGrey: 2
     ClothingHandsGlovesColorBlack: 2
     ClothingHandsGlovesLatex: 2
+    BriefcaseBrown: 1 #CorvaxGoob
     ClothingHeadsetAltSecurityRegular: 2 # Goobstation
     ClothingHeadsetSecurity: 2
   contrabandInventory:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/hellspawn.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/hellspawn.yml
@@ -78,20 +78,24 @@
   id: MobHellspawn
   description: An unstoppable force of carnage.
   components:
-  - type: GhostRole
-    allowMovement: true
-    makeSentient: true
-    name: ghost-role-information-hellspawn-name
-    description: ghost-role-information-hellspawn-description
-    rules: ghost-role-information-antagonist-rules
-    mindRoles:
-    - MindRoleGhostRoleSoloAntagonist
-    raffle:
-      settings: default
+# CorvaxGoob start
+#  - type: GhostRole
+#    allowMovement: true
+#    makeSentient: true
+#    name: ghost-role-information-hellspawn-name
+#    description: ghost-role-information-hellspawn-description
+#    rules: ghost-role-information-antagonist-rules
+#    mindRoles:
+#    - MindRoleGhostRoleSoloAntagonist
+#    raffle:
+#      settings: default
+# CorvaxGoob end
   - type: RotationVisuals
     defaultRotation: 90
     horizontalRotation: 90
-  - type: GhostTakeoverAvailable
+# CorvaxGoob start
+#  - type: GhostTakeoverAvailable
+# CorvaxGoob end
   - type: HTN
     rootTask:
       task: SimpleHostileCompound


### PR DESCRIPTION
## Описание PR
Детективу добавлен Детекшкаф чемодан
Адскому отродью удалена гост роль по умолчанию

## Почему / Баланс
У детектива слишком много вещей чтобы держать их при себе, и жонглировать ими вместе с оружием синего кода и выше. Чемодан служит как доп инвентарь для следовательских вещей.

Адские отродья больше не будут терроризировать станцию потому что кто-то не читает правила обитателей обломков

## Технические детали
Весь код связанный с гост-роль адского отродья закоменчен. Первая часть кода для гост-роли, вторая часть чтобы не ломать дебаг выдачу гост-роли.

## Медиа
<img width="417" height="300" alt="изображение" src="https://github.com/user-attachments/assets/262a75aa-6f79-40e7-ac83-95f67c3e2b9d" />

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.


**Список изменений**
:cl: Elusive
- add: Добавлен чемодан в ДетекШкаф
- remove: Гост роль Адского отродья

