### PR TITLE
Нерф Транзита

### DIFF
--- a/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Power/substations.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Power/substations.yml
@@ -4,17 +4,18 @@
   name: bluespace T.R.A.N.S.I.T.O.R.
   components:
   - type: Battery
-    maxCharge: 5000000000
-    startingCharge: 2500000
+    maxCharge: 14400000000
+    startingCharge: 0
+    pricePerJoule: 0.000000292535
   - type: PowerNetworkBattery
-    maxSupply: 3000000000
-    maxChargeRate: 5000000000
+    maxSupply: 500000000
+    maxChargeRate: 5000
     supplyRampTolerance: 1000
     supplyRampRate: 1000000000
     efficiency: 1
   - type: BatteryInterface
-    maxChargeRate: 5000000000
-    maxSupply: 3000000000
+    maxChargeRate: 1000000000
+    maxSupply: 500000000
   - type: Machine
     board: MachineBluespaceTransitorCircuitboard
   - type: Explosive


### PR DESCRIPTION
## Описание PR
Очередной нерф транзита :cat_gagaga:
- Максимального заряда хватает на 15 мин работы БСХ 15 уровня
- Цена заряженного транзита теперь РОВНО 5000 кредитов
- Стартовый заряд тразнита после сборки - 0
- Стартовая скорость заряда транзита теперь как и везде 5квт
- Максимальная скорость зарядки теперь 1000 МВТ 
- Максимальная скорость разрядки теперь 500 МВТ

## Почему / Баланс
Потому что изи мани карго нельзя, особенно полтора ляма.
Стартовый заряд после сборки это магия
Стартовая скорость зарядки транзита как у всех т.е. больше никаких блекаутов от огузков подключивших транзит к общей сети
Максимальная скорость заряда/разряда уменьшена для простоты понимания (не то чтобы вы такие цифры вообще знаете или увидите, МВТы хотябы понятней выглядят) 

## Медиа
<img width="586" height="300" alt="изображение" src="https://github.com/user-attachments/assets/69fcadb1-e22a-4b6d-8d59-0d77c06d1d74" />
<img width="582" height="294" alt="изображение" src="https://github.com/user-attachments/assets/5cc30694-50dc-48f9-919e-b333dbd562b6" />
<img width="536" height="45" alt="изображение" src="https://github.com/user-attachments/assets/30dc418d-64ce-4d9f-9e5d-e603b30a681e" />
<img width="585" height="265" alt="изображение" src="https://github.com/user-attachments/assets/10347768-a872-4196-83ee-1e3113fec5ec" />


## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.



**Список изменений**
:cl:
- remove: Удалено веселье!

