### PR TITLE
Консоль питания и харвестер

### DIFF
--- a/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Machines/bluespace_harvester.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Machines/bluespace_harvester.yml
@@ -87,7 +87,6 @@
         nodeGroupID: MVPower
   - type: PowerConsumer
     voltage: Medium
-    showInMonitor: false
   - type: AmbientSound
     enabled: false
     volume: -1
@@ -108,3 +107,8 @@
     access: [["Engineering"], ["Research"]]
   - type: GuideHelp
     guides: [ Power ] # TODO: Add harvester guide to the guidebook.
+  - type: PowerMonitoringDevice
+    sprite: _CorvaxGoob/Bluespace/Crates/technological_secure.rsi
+    state: icon
+    group: APC
+    loadNode: harvester

--- a/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Machines/bluespace_harvester.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Machines/bluespace_harvester.yml
@@ -87,6 +87,7 @@
         nodeGroupID: MVPower
   - type: PowerConsumer
     voltage: Medium
+    showInMonitor: false
   - type: AmbientSound
     enabled: false
     volume: -1
@@ -106,4 +107,4 @@
   - type: AccessReader
     access: [["Engineering"], ["Research"]]
   - type: GuideHelp
-    guides: [ Power ] # TODO: Add BH guide
+    guides: [ Power ] # TODO: Add harvester guide to the guidebook.

--- a/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Machines/bluespace_harvester.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Machines/bluespace_harvester.yml
@@ -111,4 +111,4 @@
     sprite: _CorvaxGoob/Bluespace/Crates/technological_secure.rsi
     state: icon
     group: APC
-    loadNode: harvester
+    sourceNode: input

--- a/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Power/substations.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Power/substations.yml
@@ -24,7 +24,6 @@
     intensitySlope: 20
     maxIntensity: 2500
   - type: PowerMonitoringDevice
-    sourceNode: harvester
     sprite: _CorvaxGoob/Objects/Structures/Power/bluespace_transitor.rsi
     state: display
   - type: Sprite

--- a/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Power/substations.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Structures/Power/substations.yml
@@ -24,6 +24,7 @@
     intensitySlope: 20
     maxIntensity: 2500
   - type: PowerMonitoringDevice
+    sourceNode: harvester
     sprite: _CorvaxGoob/Objects/Structures/Power/bluespace_transitor.rsi
     state: display
   - type: Sprite


### PR DESCRIPTION
## Описание PR
Добавил харвестер на консоль питания. Он больше не вызывает оповещения о несанкционированной источнике питания.

## Почему / Баланс
Я часто играю за инженеров, и пару раз смены заканчивались ходилками бродилками с поисками харвестера, пока я не спросил об этом а АХ.

## Медиа
<img width="1920" height="1080" alt="Снимок экрана от 2026-06-22 23-33-44" src="https://github.com/user-attachments/assets/a126b521-ffff-4dcb-9097-b4352597e1cc" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->


**Список изменений**
:cl:
- add: Добавлено веселье!
- remove: Удалено веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
