### PR TITLE
[Maps] Chloris end exp

### DIFF
--- a/Resources/Maps/_CorvaxGoob/Stations/Chloris/corvax_chloris.yml
+++ b/Resources/Maps/_CorvaxGoob/Stations/Chloris/corvax_chloris.yml
@@ -128,28 +128,7 @@ entities:
     - type: Parallax
       parallax: Venus
     - type: MapAtmosphere
-      space: False
-      mixture:
-        volume: 2500
-        immutable: True
-        temperature: 333
-        moles:
-        - 0
-        - 0
-        - 798
-        - 0
-        - 0
-        - 25
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+      space: True
   - uid: 2
     components:
     - type: MetaData


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Атмосфера на хлорисе  выключена и отправляется на доработку - давление вызывает взрыв окон.
