### PR TITLE
RedSpace for NukeOps

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -82,7 +82,7 @@
     back:
     - WeaponPistolViper
     - PinpointerSyndicateNuclear
-    - DeathAcidifierImplanter
+    - RedspaceLifelineImplanter # CorvaxGoob edit
 
 #Nuclear Operative Gear
 - type: startingGear
@@ -144,7 +144,7 @@
     - PinpointerSyndicateNuclear
     #- HandheldHealthAnalyzer # Goobstation
     - CombatMedipen
-    - DeathAcidifierImplanter
+    - RedspaceLifelineImplanter # CorvaxGoob edit
     - MedkitCombatFilled # Goobstation
 
 - type: chameleonOutfit


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## Описание PR
У ядерных оперативников растворитель заменен на редспейс коридор.

## Почему / Баланс
Круче выглядит, нельзя сманчить имплант вроде Сандевистана, как при растворении.

## Медиа
<img width="538" height="435" alt="image" src="https://github.com/user-attachments/assets/ab219446-f008-407d-a1a0-eb176bdb7717" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
**Список изменений**
:cl:
- tweak: У ЯО заменен имплант на растворителя на имплант редспейс коридора.
