### PR TITLE
Радиус сило 40 => 200

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/silo.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/silo.yml
@@ -17,7 +17,7 @@
           True: { state: silo_active }
           False: { state: silo }
   - type: OreSilo
-    range: 100 # CorvaxGoob community voting
+    range: 200 # CorvaxGoob community voting
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/silo.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/silo.yml
@@ -17,6 +17,7 @@
           True: { state: silo_active }
           False: { state: silo }
   - type: OreSilo
+    range: 100 # CorvaxGoob community voting
   - type: MaterialStorage
     whitelist:
       tags:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Увеличен радиус сило

## Почему / Баланс
Можно начать очень долгое обсуждение о геймдизайне, сообществе и том, что игроки часто делают неверные решения. Но я не буду. Я сам против увеличения радиуса сило, однако сами игроки играли с неограниченным сило огромное количество времени, в самой сборке множество механик ослаблено... И... Всем было хорошо? 
Вот скриношты самих опросов:
<img width="398" height="595" alt="Снимок экрана от 2026-07-22 21-43-17" src="https://github.com/user-attachments/assets/fb3a1c89-98f6-471b-87a8-b0cb951ee109" />
<img width="395" height="408" alt="Снимок экрана от 2026-07-22 21-43-27" src="https://github.com/user-attachments/assets/8d9e4e5d-19ba-4bbc-83ea-3bad1379056d" />
<img width="393" height="730" alt="Снимок экрана от 2026-07-22 21-43-32" src="https://github.com/user-attachments/assets/b7a43f14-2113-43f7-acd6-4d2e54159130" />
Можете построить из себя великого геймдизайнера в комментах, и сказать, что это понижает уровень взаимодействия между игроками. Но почему бы не дать и без того зашуганными вечными "гениями по взаимодействию" игрокам возможность просто повеселится?
Если вы все ещё считаете, что это преступление против геймдизайна, то как вы вообще эти полтора года играли с таким сило на губах? Понижение радиуса - это следствие апстрима, где у губов сило неограниченно, но требует связки мультитулом, что позволяло раундстартом иметь связанные друг с другом латы на ваниле, и сило в отделах на офф-губах.
P.S: сило ещё не соединён с латами на уровне маппинга.
P.S.S: из возможных проблем неограниченного сило, сказанных самими оффами - возможность воровать ресурсы. Но эат возможность была на КГБ уже несколько лет, и ей никто особо не псользовался

**Список изменений**
:cl:
- add: Добавлено веселье!