### PR TITLE
Фикс оптовой закупки в карго

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -9,11 +9,10 @@ using Content.Shared.Cargo.BUI;
 using Content.Shared.Cargo.Components;
 using Content.Shared.Cargo.Events;
 using Content.Shared.Cargo.Prototypes;
-using Content.Shared.Containers;
+using Content.Shared.Containers; // CorvaxGoob-CargoFeatures
 using Content.Shared.Database;
 using Content.Shared.Emag.Systems;
-using Content.Shared.EntityTable;
-using Content.Shared.EntityTable.EntitySelectors;
+using Content.Shared.EntityTable; // CorvaxGoob-CargoFeatures
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
@@ -23,7 +22,7 @@ using Content.Shared.Prototypes;
 using Content.Shared.Station.Components;
 using Content.Shared.Storage;
 using Content.Shared.Storage.Components;
-using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Storage.EntitySystems; // CorvaxGoob-CargoFeatures
 using JetBrains.Annotations;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;

--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -3,15 +3,17 @@
 using Content.Goobstation.Common.Pirates;
 using Content.Server.Access.Systems;
 using Content.Server.Cargo.Components;
-using Content.Server.Station.Components;
 using Content.Server.Storage.EntitySystems;
 using Content.Shared.Cargo;
 using Content.Shared.Cargo.BUI;
 using Content.Shared.Cargo.Components;
 using Content.Shared.Cargo.Events;
 using Content.Shared.Cargo.Prototypes;
+using Content.Shared.Containers;
 using Content.Shared.Database;
 using Content.Shared.Emag.Systems;
+using Content.Shared.EntityTable;
+using Content.Shared.EntityTable.EntitySelectors;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
@@ -21,8 +23,8 @@ using Content.Shared.Prototypes;
 using Content.Shared.Station.Components;
 using Content.Shared.Storage;
 using Content.Shared.Storage.Components;
+using Content.Shared.Storage.EntitySystems;
 using JetBrains.Annotations;
-using Microsoft.CodeAnalysis;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -41,6 +43,7 @@ namespace Content.Server.Cargo.Systems
         // CorvaxGoob-CargoFeatures-Start
         [Dependency] private readonly IdCardSystem _idCard = default!;
         [Dependency] private readonly EntityStorageSystem _entityStorage = default!;
+        [Dependency] private readonly EntityTableSystem _entityTable = default!;
         // CorvaxGoob-CargoFeatures-End
 
         [Dependency] private readonly StorageSystem _storage = default!;
@@ -726,7 +729,7 @@ namespace Content.Server.Cargo.Systems
         /// Fulfills the specified cargo order and spawns paper attached to it.
         /// </summary>
         /// CorvaxGoob-CargoFeatures : Новые аргументы функции для работы с оптовыми заказами
-        private bool FulfillOrder(CargoOrderData order, ProtoId<CargoAccountPrototype> account, EntityCoordinates spawn, string? paperProto, out EntityUid? nextCrate, out List<string>? excessItemsOut, EntityUid? previousCrate = null, List<string>? excessItemsIn = null)
+        private bool FulfillOrder(CargoOrderData order, ProtoId<CargoAccountPrototype> account, EntityCoordinates spawn, string? paperProto, out EntityUid? nextCrate, out List<string>? excessItemsOut, EntityUid? previousCrate = null, List<string>? excessItemsIn = null, bool addOrderContents = true)
         {
             // Create the item itself
             EntityUid? item = null;
@@ -741,11 +744,14 @@ namespace Content.Server.Cargo.Systems
                 return false;
 
             var productProto = _protoMan.Index<EntityPrototype>(order.ProductId);
+            var orderContents = addOrderContents
+                ? GetBulkOrderContents(productProto)
+                : new List<string>();
 
             if (previousCrate is not null) // Если указан ящик который будет заполняться
                 item = previousCrate;
             else if (order.SecuredDelivery && accountProto.SecureCratePrototype is not null // Если поставлена галочка на защиту заказа
-                && (productProto.TryGetComponent<ItemComponent>(out var itemComponent) || productProto.HasComponent<EntityStorageComponent>())) // и может ли этот заказ быть помещен в ящик?
+                && (productProto.TryGetComponent<ItemComponent>(out var itemComponent, Factory) || productProto.HasComponent<EntityStorageComponent>())) // и может ли этот заказ быть помещен в ящик?
             {
                 item = Spawn(accountProto.SecureCratePrototype, spawn);
 
@@ -757,34 +763,32 @@ namespace Content.Server.Cargo.Systems
                 item = EntityManager.CreateEntityUninitialized(productProto.ID, spawn);
 
                 // Очистить автозаполнение при спавне для пополнения содержимого саморучно в коде снизу
-                RemComp<StorageFillComponent>(item.Value);
+                if (orderContents is not null)
+                {
+                    RemComp<StorageFillComponent>(item.Value);
+                    RemComp<EntityTableContainerFillComponent>(item.Value);
+                }
 
                 EntityManager.InitializeAndStartEntity(item.Value);
             }
 
             // Если предмет заказа имеет в себе заполняемость и является хранилищем
-            if (productProto.TryGetComponent<StorageFillComponent>(out var storageFill)
+            if (orderContents is not null
                 && TryComp<EntityStorageComponent>(item, out var crateEntityStorage))
             {
                 nextCrate = item;
 
                 // Избыток предметов при заполнении
                 var entitiesExcess = new List<string>();
-                bool doExcessFill = false;
 
                 if (excessItemsIn is not null) // Если предметы из избытка были переданы в функцию — помещаем их первыми
                     foreach (var excessItem in excessItemsIn)
-                        _storage.Insert(item.Value, Spawn(excessItem), out var stacked);
+                        _entityStorage.Insert(Spawn(excessItem), item.Value);
 
-                // Проходимся по всему содержимому StorageFill и помещаем в ящик, если цикл не был закончен и при этом места уже нету
-                // То весь избыток отправляется в список который передаётся на выход из функции для следующего круга
-                var spawns = EntitySpawnCollection.GetSpawns(storageFill.Contents, _random);
-                foreach (var contentItem in spawns)
+                // Всё, что не поместилось, передаётся для заполнения следующего ящика.
+                foreach (var contentItem in orderContents)
                 {
-                    if (crateEntityStorage.Contents.Count >= crateEntityStorage.Capacity && spawns.Count <= crateEntityStorage.Capacity)
-                        doExcessFill = true;
-
-                    if (doExcessFill)
+                    if (crateEntityStorage.Contents.Count >= crateEntityStorage.Capacity && orderContents.Count <= crateEntityStorage.Capacity)
                     {
                         entitiesExcess.Add(contentItem);
                         continue;
@@ -794,7 +798,22 @@ namespace Content.Server.Cargo.Systems
                 }
 
                 if (entitiesExcess.Count != 0)
+                {
+                    // Последний заказ тоже может переполнить предыдущий ящик, поэтому остаток можно сразу отправить в новый ящик
+                    if (order.NumDispatched + 1 >= order.OrderQuantity && previousCrate is not null)
+                    {
+                        return FulfillOrder(order,
+                            account,
+                            spawn,
+                            paperProto,
+                            out nextCrate,
+                            out excessItemsOut,
+                            excessItemsIn: entitiesExcess,
+                            addOrderContents: false);
+                    }
+
                     excessItemsOut = entitiesExcess;
+                }
             }
 
 
@@ -852,6 +871,35 @@ namespace Content.Server.Cargo.Systems
         private bool FulfillOrder(CargoOrderData order, ProtoId<CargoAccountPrototype> account, EntityCoordinates spawn, string? paperProto)
         {
             return FulfillOrder(order, account, spawn, paperProto, out _, out _);
+        }
+
+
+        // CorvaxGoob-CargoFeatures : Получение содержимого товара для объединения оптовых заказов
+        private List<string>? GetBulkOrderContents(EntityPrototype productProto)
+        {
+            if (productProto.TryGetComponent<StorageFillComponent>(out var storageFill, Factory)) // удалить блок с удалением компонента
+            {
+                return EntitySpawnCollection.GetSpawns(storageFill.Contents, _random);
+            }
+
+            if (!productProto.TryGetComponent<EntityTableContainerFillComponent>(out var containerFill, Factory))
+            {
+                return null;
+            }
+
+            var containers = containerFill.Containers;
+
+            if (containers.Count != 1
+                || !containers.TryGetValue(
+                    SharedEntityStorageSystem.ContainerName,
+                    out var entityTable))
+            {
+                return null;
+            }
+
+            return _entityTable.GetSpawns(entityTable)
+                .Select(prototype => prototype.Id)
+                .ToList();
         }
 
         public List<ProtoId<CargoProductPrototype>> GetAvailableProducts(Entity<CargoOrderConsoleComponent> ent)

--- a/Content.Shared/Cargo/SharedCargoSystem.cs
+++ b/Content.Shared/Cargo/SharedCargoSystem.cs
@@ -4,7 +4,7 @@ using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Cargo.Components;
 using Content.Shared.Cargo.Prototypes;
-using Content.Shared.Containers;
+using Content.Shared.Containers; // CorvaxGoob-CargoFeatures
 using Content.Shared.IdentityManagement;
 using Content.Shared.Item;
 using Content.Shared.Prototypes;

--- a/Content.Shared/Cargo/SharedCargoSystem.cs
+++ b/Content.Shared/Cargo/SharedCargoSystem.cs
@@ -4,11 +4,12 @@ using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Cargo.Components;
 using Content.Shared.Cargo.Prototypes;
-using JetBrains.Annotations;
+using Content.Shared.Containers;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Item;
 using Content.Shared.Prototypes;
 using Content.Shared.Storage.Components;
+using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
@@ -234,7 +235,8 @@ public abstract class SharedCargoSystem : EntitySystem
     {
         var access = Proto.Index<CargoAccountPrototype>(entity.Comp.Account).SecureCrateOrderAccess;
 
-        if (productProto.HasComponent<StorageFillComponent>())
+        if (productProto.HasComponent<StorageFillComponent>()
+            || productProto.HasComponent<EntityTableContainerFillComponent>())
         {
             if (productProto.TryGetComponent<AccessReaderComponent>(out var reader)
             && access is not null


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
<!-- Что вы изменили? -->
Апстрим сломал систему оптовой закупки в карго, исправлено

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Визарды заменили теперь устаревший `StorageFillComponent` на `EntityTableContainerFillComponent` из за чего текущая система закупок оптом сломалась. Добавил туда обработку `EntityTableContainerFillComponent` чтобы оно вновь заработало

Кроме этого заметил что старая оптовая закупка в ручном заполнении ящиков иногда оставляла часть вещей неучтенными и удаляла их, поправил это тоже

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl: Skarpelen
- fix: Починка оптовых закупок
- fix: Исправление периодического пропадания части заказа при оптовой закупке