### PR TITLE
Revert explosions buff

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -487,7 +487,7 @@ public sealed partial class ExplosionSystem
 
                 // TODO EXPLOSIONS turn explosions into entities, and pass the the entity in as the damage origin.
                 if (!WouldTriggerDestructibleThreshold(entity, damage, cause))
-                    _damageableSystem.TryChangeDamage(entity, damage, ignoreResistances: true, targetPart: TargetBodyPart.All, splitDamage: SplitDamageBehavior.SplitExplosion); // Shitmed Change
+                    _damageableSystem.TryChangeDamage(entity, damage, ignoreResistances: true, targetPart: TargetBodyPart.All, splitDamage: SplitDamageBehavior.Split); // Shitmed Change
             }
         }
 

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -487,7 +487,10 @@ public sealed partial class ExplosionSystem
 
                 // TODO EXPLOSIONS turn explosions into entities, and pass the the entity in as the damage origin.
                 if (!WouldTriggerDestructibleThreshold(entity, damage, cause))
+                    // CorvaxGoob edit start
+                    //_damageableSystem.TryChangeDamage(entity, damage, ignoreResistances: true, targetPart: TargetBodyPart.All, splitDamage: SplitDamageBehavior.SplitExplosion); // Shitmed Change
                     _damageableSystem.TryChangeDamage(entity, damage, ignoreResistances: true, targetPart: TargetBodyPart.All, splitDamage: SplitDamageBehavior.Split); // Shitmed Change
+                    // CorvaxGoob edit end
             }
         }
 

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -646,12 +646,6 @@ namespace Content.Shared.Damage
                     return newDamage;
                 case SplitDamageBehavior.Split:
                     return newDamage / parts.Count;
-                case SplitDamageBehavior.SplitExplosion:
-                    var vitalParts = parts.Where(part =>
-                    TryComp<ConsciousnessRequiredComponent>(part.Id, out var consciousness)
-                    && consciousness.CausesDeath == true).ToList();
-
-                    return newDamage / vitalParts.Count;
                 case SplitDamageBehavior.SplitEnsureAllDamaged:
                     var damagedParts = parts.Where(part =>
                         part.Damageable.TotalDamage > FixedPoint2.Zero).ToList();

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -646,6 +646,14 @@ namespace Content.Shared.Damage
                     return newDamage;
                 case SplitDamageBehavior.Split:
                     return newDamage / parts.Count;
+                // CorvaxGoob edit start
+                //case SplitDamageBehavior.SplitExplosion:
+                //    var vitalParts = parts.Where(part =>
+                //    TryComp<ConsciousnessRequiredComponent>(part.Id, out var consciousness)
+                //    && consciousness.CausesDeath == true).ToList();
+                //
+                //    return newDamage / vitalParts.Count;
+                // CorvaxGoob edit end
                 case SplitDamageBehavior.SplitEnsureAllDamaged:
                     var damagedParts = parts.Where(part =>
                         part.Damageable.TotalDamage > FixedPoint2.Zero).ToList();

--- a/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
+++ b/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
@@ -6,7 +6,6 @@ public enum SplitDamageBehavior
 {
     None,
     Split,
-    SplitExplosion,
     SplitEnsureAllOrganic,
     SplitEnsureAllDamaged,
     SplitEnsureAllDamagedAndOrganic,

--- a/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
+++ b/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
@@ -6,7 +6,7 @@ public enum SplitDamageBehavior
 {
     None,
     Split,
-    // SplitExplosion,
+    // SplitExplosion, // CorvaxGoob edit
     SplitEnsureAllOrganic,
     SplitEnsureAllDamaged,
     SplitEnsureAllDamagedAndOrganic,

--- a/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
+++ b/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
@@ -6,6 +6,7 @@ public enum SplitDamageBehavior
 {
     None,
     Split,
+    // SplitExplosion,
     SplitEnsureAllOrganic,
     SplitEnsureAllDamaged,
     SplitEnsureAllDamagedAndOrganic,


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Откатил изменения из этого ПРа https://github.com/Goob-Station/Goob-Station/pull/6827.

## Почему / Баланс
Шутка вышла несмешная, когда лук со структурным взрывом стал оружием аннигиляции, а хлор и фтор гибают. Игроки не оценили и вообще инстакилы это плохо

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
:cl:
- tweak: Урон от взрывов снова распределяется по всем частям тела, а не только по жизненно важным.
