### PR TITLE
Отключены картинки штампов

### DIFF
--- a/Resources/Maps/_CorvaxGoob/Stations/Astra/corvax_astra.yml
+++ b/Resources/Maps/_CorvaxGoob/Stations/Astra/corvax_astra.yml
@@ -261085,7 +261085,7 @@ entities:
       stampedBy:
       - hasIcon: True
         stampFont: null
-        stampLargeIcon: large_stamp-centcom
+        stampLargeIcon: null
         stampedColor: '#006600FF'
         stampedName: stamp-component-stamped-name-centcom
       content: "\n\n\n                 В рамках эксперемента ОСЩ обязан носить \n                             свою НОВУЮ униформу на станции \n        Астра! Униформа стоит в центре вашей комнаты ОСЩ!\n                \n\n\n      С любовью, офицер специальный операций."

--- a/Resources/Maps/_CorvaxGoob/Stations/Bagel/corvax_bagel.yml
+++ b/Resources/Maps/_CorvaxGoob/Stations/Bagel/corvax_bagel.yml
@@ -125766,7 +125766,7 @@ entities:
       stampedBy:
       - hasIcon: True
         stampFont: null
-        stampLargeIcon: large_stamp-qm
+        stampLargeIcon: null
         stampedColor: '#A23E3EFF'
         stampedName: stamp-component-stamped-name-qm
       content: Не забивайте болт на почту и заказы с консоли. Хоть альтернатива в виде разбора станции и фальшивомонетничества и манят, но ЦентКом нас набутылит, когда начнёт циферки по финансам подсчитывать. Вы же не хотите поехать на нары?
@@ -126291,7 +126291,7 @@ entities:
       stampedBy:
       - hasIcon: True
         stampFont: null
-        stampLargeIcon: large_stamp-hop
+        stampLargeIcon: null
         stampedColor: '#6EC0EAFF'
         stampedName: stamp-component-stamped-name-hop
       content: Привет! Вы попали в небольшой музей. К сожалению, в нём нехватает экспонатов. Если вы хотите что-то добавить в него - прошу обращаться к Главе персонала, либо же к любому сервиснику с доступами сюда. Заранее спасибо.
@@ -126407,7 +126407,7 @@ entities:
       stampedBy:
       - hasIcon: True
         stampFont: null
-        stampLargeIcon: large_stamp-cmo
+        stampLargeIcon: null
         stampedColor: '#33CCFFFF'
         stampedName: stamp-component-stamped-name-cmo
       content: 'До красного кода КРАЙНЕ ЖЕЛАТЕЛЬНО вести отчётность по попадающим в отдел гуманоидам: фио, дата и причина визита. Не то чтобы нас сильно душила бюрократия, но всё же приятно знать кто и из-за чего пострадал. '

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -757,7 +757,7 @@
     stampedName: stamp-component-stamped-name-hamlet
     stampedColor: "#1c1c1c"
     stampState: "paper_stamp-hamster"
-    # Corvax stampLargeIcon: "large_stamp-hamster"
+    stampLargeIcon: "large_stamp-hamster"
 
 - type: entity
   parent: MobHamsterHamlet

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -757,7 +757,7 @@
     stampedName: stamp-component-stamped-name-hamlet
     stampedColor: "#1c1c1c"
     stampState: "paper_stamp-hamster"
-    stampLargeIcon: "large_stamp-hamster"
+    # Corvax stampLargeIcon: "large_stamp-hamster"
 
 - type: entity
   parent: MobHamsterHamlet

--- a/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
@@ -49,7 +49,7 @@
     stampedName: stamp-component-stamped-name-captain
     stampedColor: "#3681bb"
     stampState: "paper_stamp-cap"
-    stampLargeIcon: "large_stamp-cap" # Goob
+    # Corvax stampLargeIcon: "large_stamp-cap" # Goob
   - type: Sprite
     state: stamp-cap
 
@@ -63,7 +63,7 @@
     stampedName: stamp-component-stamped-name-centcom
     stampedColor: "#006600"
     stampState: "paper_stamp-centcom"
-    stampLargeIcon: "large_stamp-centcom" # Goob
+    # Corvax stampLargeIcon: "large_stamp-centcom" # Goob
   - type: Sprite
     state: stamp-centcom
 
@@ -77,7 +77,7 @@
     stampedName: stamp-component-stamped-name-chaplain
     stampedColor: "#d70601"
     stampState: "paper_stamp-chaplain"
-    stampLargeIcon: "large_stamp-chap" # Goob
+    # Corvax stampLargeIcon: "large_stamp-chap" # Goob
   - type: Sprite
     state: stamp-chaplain
 
@@ -91,7 +91,7 @@
     stampedName: stamp-component-stamped-name-lawyer
     stampedColor: "#233D57"
     stampState: "paper_stamp-lawyer"
-    stampLargeIcon: "large_stamp-law" # Goob
+    # Corvax stampLargeIcon: "large_stamp-law" # Goob
   - type: Sprite
     state: stamp-lawyer
 
@@ -105,7 +105,7 @@
     stampedName: stamp-component-stamped-name-clown
     stampedColor: "#ff33cc"
     stampState: "paper_stamp-clown"
-    stampLargeIcon: "large_stamp-clown" # Goob
+    # Corvax stampLargeIcon: "large_stamp-clown" # Goob
   - type: Sprite
     state: stamp-clown
 
@@ -119,7 +119,7 @@
     stampedName: stamp-component-stamped-name-ce
     stampedColor: "#c69b17"
     stampState: "paper_stamp-ce"
-    stampLargeIcon: "large_stamp-ce" # Goob
+    # Corvax stampLargeIcon: "large_stamp-ce" # Goob
   - type: Sprite
     state: stamp-ce
 
@@ -133,7 +133,7 @@
     stampedName: stamp-component-stamped-name-cmo
     stampedColor: "#33ccff"
     stampState: "paper_stamp-cmo"
-    stampLargeIcon: "large_stamp-cmo" # Goob
+    # Corvax stampLargeIcon: "large_stamp-cmo" # Goob
   - type: Sprite
     state: stamp-cmo
 
@@ -147,7 +147,7 @@
     stampedName: stamp-component-stamped-name-hop
     stampedColor: "#6ec0ea"
     stampState: "paper_stamp-hop"
-    stampLargeIcon: "large_stamp-hop" # Goob
+    # Corvax stampLargeIcon: "large_stamp-hop" # Goob
   - type: Sprite
     state: stamp-hop
 
@@ -161,7 +161,7 @@
     stampedName: stamp-component-stamped-name-hos
     stampedColor: "#cc0000"
     stampState: "paper_stamp-hos"
-    stampLargeIcon: "large_stamp-hos" # Goob
+    # Corvax stampLargeIcon: "large_stamp-hos" # Goob
   - type: Sprite
     state: stamp-hos
 
@@ -175,7 +175,7 @@
     stampedName: stamp-component-stamped-name-mime
     stampedColor: "#777777"
     stampState: "paper_stamp-mime"
-    stampLargeIcon: "large_stamp-mime" # Goob
+    # Corvax stampLargeIcon: "large_stamp-mime" # Goob
     sound: null
   - type: Sprite
     state: stamp-mime
@@ -190,7 +190,7 @@
     stampedName: stamp-component-stamped-name-qm
     stampedColor: "#a23e3e"
     stampState: "paper_stamp-qm"
-    stampLargeIcon: "large_stamp-qm" # Goob
+    # Corvax stampLargeIcon: "large_stamp-qm" # Goob
   - type: Sprite
     state: stamp-qm
 
@@ -204,7 +204,7 @@
     stampedName: stamp-component-stamped-name-rd
     stampedColor: "#1f66a0"
     stampState: "paper_stamp-rd"
-    stampLargeIcon: "large_stamp-rd" # Goob
+    # Corvax stampLargeIcon: "large_stamp-rd" # Goob
   - type: Sprite
     state: stamp-rd
 
@@ -230,7 +230,7 @@
     stampedName: stamp-component-stamped-name-syndicate
     stampedColor: "#850000"
     stampState: "paper_stamp-syndicate"
-    stampLargeIcon: "large_stamp-syndicate" # Goob
+    # Corvax stampLargeIcon: "large_stamp-syndicate" # Goob
   - type: Sprite
     state: stamp-syndicate
   - type: StaticPrice
@@ -258,7 +258,7 @@
     stampedName: stamp-component-stamped-name-approved
     stampedColor: "#00be00"
     stampState: "paper_stamp-ok"
-    stampLargeIcon: "large_stamp-ok" # goob
+    # Corvax stampLargeIcon: "large_stamp-ok" # goob
   - type: Sprite
     state: stamp-ok
 
@@ -271,7 +271,7 @@
     stampedName: stamp-component-stamped-name-denied
     stampedColor: "#a23e3e"
     stampState: "paper_stamp-deny"
-    stampLargeIcon: "large_stamp-deny" # goob
+    # Corvax stampLargeIcon: "large_stamp-deny" # goob
   - type: Sprite
     state: stamp-deny
 

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/rubber_stamp.yml
@@ -9,7 +9,7 @@
     stampedName: stamp-component-stamped-name-nanorep
     stampedColor: "#2ec69b"
     stampState: "paper_stamp-nanorep"
-    stampLargeIcon: "large_stamp-centcom" # Icon
+    # Corvax stampLargeIcon: "large_stamp-centcom" # Icon
   - type: Sprite
     sprite: _Goobstation/Objects/Misc/stamps.rsi
     state: stamp-nanorep


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Отключение губовских пнг штампов, кроме печати хомяка. Печать хомяка оставлена, так как не содержит текста.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Нарушает единообразие текстур штампов- одни просто текстовые, другие с текстом-картинкой.
Убивает смысл печати-хамелеона - она позволяет лишь вписывать текст.
Ломает большинство кастомных печатей на картах из-за жесткого приоритета stampLargeIcon над stampedName. 
Печати не локализованы.

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Закомментированы строки в компонентах печатей без изменения кода.

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
<img width="1297" height="555" alt="image" src="https://github.com/user-attachments/assets/e1f08cb5-4747-43cf-9d6d-53e51e66850f" />
