### PR TITLE
CriminalRecords patchfix

### DIFF
--- a/Content.Client/CriminalRecords/CrimeHistoryWindow.xaml.cs
+++ b/Content.Client/CriminalRecords/CrimeHistoryWindow.xaml.cs
@@ -23,6 +23,8 @@ public sealed partial class CrimeHistoryWindow : FancyWindow
     public Action<uint>? OnDeleteHistory;
     public Action<uint>? OnPrint; // CorvaxGoob-SecurityFeatures
 
+    private Dictionary<uint, bool> _printableIndexs = new(); // CorvaxGoob-SecurityFeatures
+
     private uint _maxLength;
     private uint? _index;
     private DialogWindow? _dialog;
@@ -75,7 +77,7 @@ public sealed partial class CrimeHistoryWindow : FancyWindow
             // prevent MoveToFront being called on a closed window and double closing
             _dialog.OnClose += () => { _dialog = null; };
         };
-        DeleteButton.OnPressed += _ => 
+        DeleteButton.OnPressed += _ =>
         {
             if (_index is not {} index)
                 return;
@@ -101,7 +103,9 @@ public sealed partial class CrimeHistoryWindow : FancyWindow
         {
             _index = (uint) args.ItemIndex;
             DeleteButton.Disabled = false;
-            PrintButton.Disabled = false; // CorvaxGoob-SecurityFeatures
+
+            if (_printableIndexs.TryGetValue(_index.Value, out var printable) && !printable) // CorvaxGoob-SecurityFeatures
+                _index = null;
         };
         History.OnItemDeselected += args =>
         {
@@ -114,7 +118,7 @@ public sealed partial class CrimeHistoryWindow : FancyWindow
     // CorvaxGoob-SecurityFeatures
     protected override void FrameUpdate(FrameEventArgs args)
     {
-        PrintButton.Disabled = _component?.NextPrintTime >= _timing.CurTime || _index is  null ? true : false;
+        PrintButton.Disabled = _component?.NextPrintTime >= _timing.CurTime || _index is null ? true : false;
     }
 
     public void UpdateHistory(CriminalRecord record, bool access)
@@ -124,10 +128,16 @@ public sealed partial class CrimeHistoryWindow : FancyWindow
 
         NoHistory.Visible = record.History.Count == 0;
 
+        _printableIndexs.Clear(); // CorvaxGoob-SecurityFeatures
+        uint ind = 0;
         foreach (var entry in record.History)
         {
             var time = entry.AddTime;
             var line = $"{time.Hours:00}:{time.Minutes:00}:{time.Seconds:00} - {entry.Crime}";
+
+            _printableIndexs.Add(ind, entry.Status == Shared.Security.SecurityStatus.Detained || entry.Status == Shared.Security.SecurityStatus.Wanted ? true : false); // CorvaxGoob-SecurityFeatures
+            ind++; // CorvaxGoob-SecurityFeatures
+
             History.AddItem(line);
         }
 

--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleBoundUserInterface.cs
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleBoundUserInterface.cs
@@ -40,9 +40,12 @@ public sealed class CriminalRecordsConsoleBoundUserInterface : BoundUserInterfac
             SendMessage(new CriminalRecordChangeStatus(status, null));
         _window.OnDialogConfirmed += (status, reason) =>
             SendMessage(new CriminalRecordChangeStatus(status, reason));
-        // CorvaxGoob-SecurityFeatures
+        // CorvaxGoob-SecurityFeatures-Start
         _window.OnDialogDetainedConfirmed += (articles, duration, print) =>
             SendMessage(new CriminalRecordChangeDetainedStatus(articles, duration, print));
+        _window.OnDialogWantedConfirmed += (reason, print) =>
+            SendMessage(new CriminalRecordChangeWantedStatus(reason, print));
+        // CorvaxGoob-SecurityFeatures-End
         _window.OnStatusFilterPressed += (statusFilter) =>
             SendMessage(new CriminalRecordSetStatusFilter(statusFilter));
         _window.OnHistoryUpdated += UpdateHistory;

--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml
@@ -155,7 +155,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                         </PanelContainer.PanelOverride>
                             <controls:TableContainer Name="EntriesContainer" Columns="3" HorizontalExpand="True" VerticalExpand="True" Margin="5 0">
                                 <RichTextLabel Text="Время" HorizontalAlignment="Center"/>
-                                <RichTextLabel Text="Преступление" HorizontalAlignment="Center"/>
+                                <RichTextLabel Text="Статус" HorizontalAlignment="Center"/>
                                 <RichTextLabel Text="Инициатор" HorizontalAlignment="Center"/>
                             </controls:TableContainer>
                     </PanelContainer>

--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml.cs
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml.cs
@@ -406,6 +406,9 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
         if (visual.EyesColor is not null)
             targetHumanoid.EyeColor = visual.EyesColor.Value;
 
+        if (visual.Sex is not null)
+            targetHumanoid.Sex = visual.Sex.Value;
+
         _humanoidAppearance.UpdateSprite((_previewEntity.Value, targetHumanoid, _entManager.GetComponent<SpriteComponent>(_previewEntity.Value)));
 
         SpriteView.SetEntity(_previewEntity.Value);

--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml.cs
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml.cs
@@ -2,7 +2,6 @@
 
 using Content.Client.Humanoid;
 using Content.Client.Message;
-using Content.Client.Station;
 using Content.Client.UserInterface.Controls;
 using Content.Shared.Access.Systems;
 using Content.Shared.Administration;
@@ -55,6 +54,7 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
     public Action? OnHistoryClosed;
     public Action<SecurityStatus, string>? OnDialogConfirmed;
     public Action<string, int, bool>? OnDialogDetainedConfirmed; // CorvaxGoob-SecurityFeatures
+    public Action<string, bool>? OnDialogWantedConfirmed; // CorvaxGoob-SecurityFeatures
 
     public Action<SecurityStatus>? OnStatusFilterPressed;
     private uint _maxLength;
@@ -275,10 +275,10 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
         }
 
         // CorvaxGoob-SecurityFeatures-Start
+        EntriesContainer.RemoveAllChildren();
+
         if (criminalRecord.History.Count > 0)
         {
-            EntriesContainer.RemoveAllChildren();
-
             // Heading
             var historyRecordHeadTime = new RichTextLabel
             {
@@ -291,7 +291,7 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
             {
                 HorizontalAlignment = HAlignment.Center,
             };
-            historyRecordHeadCrime.SetMarkup(Loc.GetString("Преступление"));
+            historyRecordHeadCrime.SetMarkup(Loc.GetString("Статус"));
             EntriesContainer.AddChild(historyRecordHeadCrime);
 
             var historyRecordHeadInitiator = new RichTextLabel
@@ -356,13 +356,16 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
             Initiator.SetMessage(message);
             Initiator.Visible = true;
         }
+        else
+        {
+            Initiator.Visible = false;
+        }
 
         UpdatePreview(stationRecord); // CorvaxGoob-SecurityFeatures
 
         StatusOptionButton.SelectId((int)criminalRecord.Status);
         if (criminalRecord.Reason is { } reason)
         {
-
             var message = FormattedMessage.FromMarkupOrThrow(Loc.GetString($"criminal-records-console-{criminalRecord.Status.ToString().ToLower()}-reason"));
             message.AddText($": {reason}");
 
@@ -427,8 +430,7 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
 
     private void SetStatus(SecurityStatus status)
     {
-        if (status == SecurityStatus.Wanted
-            || status == SecurityStatus.Suspected
+        if (status == SecurityStatus.Suspected // CorvaxGoob-SecurityFeatures : Удалён Wanted
             || status == SecurityStatus.Hostile
             || status == SecurityStatus.Search // Goobstation
             || status == SecurityStatus.Dangerous // Goobstation
@@ -442,6 +444,13 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
         if (status == SecurityStatus.Detained)
         {
             GetDetainedInfo();
+            return;
+        }
+
+        // CorvaxGoob-SecurityFeatures
+        if (status == SecurityStatus.Wanted)
+        {
+            GetWantedReason();
             return;
         }
 
@@ -513,6 +522,38 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
 
         _reasonDialog.OnClose += () => { _reasonDialog = null; };
     }
+
+    // CorvaxGoob-SecurityFeatures
+    private void GetWantedReason()
+    {
+        if (_reasonDialog != null)
+        {
+            _reasonDialog.MoveToFront();
+            return;
+        }
+
+        var field = "reason";
+        var title = Loc.GetString("criminal-records-status-wanted");
+        var placeholders = _proto.Index(ReasonPlaceholders);
+        var placeholder = Loc.GetString("criminal-records-console-reason-placeholder", ("placeholder", Loc.GetString(_random.Pick(placeholders.Values)))); // CorvaxGoob-SecurityFeatures
+        var prompt = Loc.GetString("criminal-records-console-reason");
+
+        var entry = new QuickDialogEntry(field, QuickDialogEntryType.LongText, prompt, placeholder);
+        var entries = new List<QuickDialogEntry>() { entry };
+        _reasonDialog = new DialogWindow(title, entries, true, true, true, Loc.GetString("criminal-records-console-print"));
+
+        _reasonDialog.OnConfirmed += responses =>
+        {
+            var reason = responses[field];
+            if (reason.Length < 1 || reason.Length > _maxLength)
+                return;
+
+            OnDialogWantedConfirmed?.Invoke(reason, _reasonDialog.CheckBox.Pressed);
+        };
+
+        _reasonDialog.OnClose += () => { _reasonDialog = null; };
+    }
+
     private string GetStatusIcon(SecurityStatus status)
     {
         return status switch

--- a/Content.Server/CriminalRecords/Systems/CriminalRecordsConsoleSystem.cs
+++ b/Content.Server/CriminalRecords/Systems/CriminalRecordsConsoleSystem.cs
@@ -17,7 +17,6 @@ using Content.Shared.GameTicking;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Paper;
 using Content.Shared.Security;
-using Content.Shared.Security.Components;
 using Content.Shared.StationRecords;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;
@@ -61,6 +60,7 @@ public sealed partial class CriminalRecordsConsoleSystem : SharedCriminalRecords
             subs.Event<SetStationRecordFilter>(OnFiltersChanged);
             subs.Event<CriminalRecordChangeStatus>(OnChangeStatus);
             subs.Event<CriminalRecordChangeDetainedStatus>(OnChangeDetainedStatus); // CorvaxGoob-SecurityFeatures
+            subs.Event<CriminalRecordChangeWantedStatus>(OnChangeWantedStatus); // CorvaxGoob-SecurityFeatures
             subs.Event<CriminalRecordAddHistory>(OnAddHistory);
             subs.Event<CriminalRecordDeleteHistory>(OnDeleteHistory);
             subs.Event<CriminalRecordPrint>(OnPrint); // CorvaxGoob-SecurityFeatures
@@ -218,6 +218,12 @@ public sealed partial class CriminalRecordsConsoleSystem : SharedCriminalRecords
             // this is impossible
             _ => "not-wanted"
         };
+
+        // CorvaxGoob-SecurityFeatures : Записывается любое изменение статуса
+        _criminalRecords.TryAddHistory(key.Value, Loc.GetString($"criminal-records-console-history",
+            ("status", Loc.GetString($"criminal-records-status-{statusString}")),
+            ("reason", reason ?? Loc.GetString($"criminal-records-console-unspecified"))), officer, status: msg.Status);
+
         _radio.SendRadioMessage(ent, Loc.GetString($"criminal-records-console-{statusString}", args),
             ent.Comp.SecurityChannel, ent);
 
@@ -248,13 +254,11 @@ public sealed partial class CriminalRecordsConsoleSystem : SharedCriminalRecords
                 return;
         }
 
-        var oldStatus = record.Status;
-
         var name = _records.RecordName(key.Value);
         GetOfficer(mob.Value, out var officer);
 
         var history = Loc.GetString("criminal-records-console-detained-record", ("articles", articles ?? Loc.GetString("criminal-records-console-unspecified")), ("duration", msg.Duration?.ToString() ?? Loc.GetString("criminal-records-console-unspecified")));
-        _criminalRecords.TryAddHistory(key.Value, history, officer, articles, msg.Duration);
+        _criminalRecords.TryAddHistory(key.Value, history, officer, articles, msg.Duration, status: SecurityStatus.Detained);
 
         // will probably never fail given the checks above
         name = _records.RecordName(key.Value);
@@ -286,14 +290,75 @@ public sealed partial class CriminalRecordsConsoleSystem : SharedCriminalRecords
         {
             ent.Comp.NextPrintTime = _timing.CurTime + ent.Comp.PrintCooldown;
 
-            PrintDocument(ent, msg.Actor, entry, articles, msg.Duration);
+            PrintDetainedDocument(ent, msg.Actor, entry, articles, msg.Duration);
             Dirty(ent);
         }
 
         UpdateUserInterface(ent);
     }
 
-    private void PrintDocument(Entity<CriminalRecordsConsoleComponent> ent, EntityUid officer, GeneralStationRecord record, string? articles, int? duration)
+    // CorvaxGoob-SecurityFeatures
+    private void OnChangeWantedStatus(Entity<CriminalRecordsConsoleComponent> ent, ref CriminalRecordChangeWantedStatus msg)
+    {
+        if (!CheckSelected(ent, msg.Actor, out var mob, out var key))
+            return;
+
+        if (!_records.TryGetRecord<CriminalRecord>(key.Value, out var record))
+            return;
+
+        var name = _records.RecordName(key.Value);
+        GetOfficer(mob.Value, out var officer);
+
+        name = _records.RecordName(key.Value);
+
+        officer = Loc.GetString("criminal-records-console-unknown-officer");
+        var jobName = "Unknown";
+
+        _records.TryGetRecord<GeneralStationRecord>(key.Value, out var entry);
+        if (entry != null)
+            jobName = entry.JobTitle;
+
+        var tryGetIdentityShortInfoEvent = new TryGetIdentityShortInfoEvent(null, mob.Value);
+        RaiseLocalEvent(tryGetIdentityShortInfoEvent);
+        if (tryGetIdentityShortInfoEvent.Title != null)
+            officer = tryGetIdentityShortInfoEvent.Title;
+
+        _criminalRecords.TryChangeStatus(key.Value, SecurityStatus.Wanted, msg.Reason, officer);
+
+        string? reason = null;
+        if (msg.Reason != null)
+        {
+            reason = msg.Reason.Trim();
+            if (reason.Length < 1 || reason.Length > ent.Comp.MaxStringLength)
+                return;
+        }
+
+        (string, object)[] args;
+        if (reason != null)
+            args = new (string, object)[] { ("name", name), ("officer", officer), ("reason", reason), ("job", jobName) };
+        else
+            args = new (string, object)[] { ("name", name), ("officer", officer), ("job", jobName) };
+
+
+        _criminalRecords.TryAddHistory(key.Value, Loc.GetString($"criminal-records-console-history",
+            ("status", Loc.GetString($"criminal-records-status-wanted")),
+            ("reason", reason ?? Loc.GetString($"criminal-records-console-unspecified"))), officer, status: SecurityStatus.Wanted);
+
+        _radio.SendRadioMessage(ent, Loc.GetString($"criminal-records-console-wanted", args),
+            ent.Comp.SecurityChannel, ent);
+
+        if (msg.Print && entry is not null)
+        {
+            ent.Comp.NextPrintTime = _timing.CurTime + ent.Comp.PrintCooldown;
+
+            PrintWantedDocument(ent, msg.Actor, entry);
+            Dirty(ent);
+        }
+
+        UpdateUserInterface(ent);
+    }
+
+    private void PrintDetainedDocument(Entity<CriminalRecordsConsoleComponent> ent, EntityUid officer, GeneralStationRecord record, string? articles, int? duration)
     {
         var content = Loc.GetString("doc-text-printer-sentence");
 
@@ -327,7 +392,36 @@ public sealed partial class CriminalRecordsConsoleSystem : SharedCriminalRecords
             _paperSystem.SetContent(printed, content);
             _audio.PlayPvs(new SoundPathSpecifier("/Audio/Machines/printer.ogg"), ent);
         }
+    }
 
+    // CorvaxGoob-SecurityFeatures
+    private void PrintWantedDocument(Entity<CriminalRecordsConsoleComponent> ent, EntityUid officer, GeneralStationRecord record)
+    {
+        var content = Loc.GetString("doc-text-printer-closing-indictment");
+
+        var station = _station.GetOwningStation(ent);
+        var stationName = station != null ? Name(station.Value) : null;
+
+        var time = _gameTicker.RoundDuration().ToString("hh\\:mm\\:ss") + " " + DateTime.Now.AddYears(1000).ToShortDateString();
+
+        content = content
+            .Replace(Loc.GetString("doc-var-station"), stationName ?? Loc.GetString("doc-text-printer-default-station"))
+            .Replace(Loc.GetString("doc-var-date"), time);
+
+        if (_idCard.TryFindIdCard(officer, out var idCard))
+        {
+            content = content
+            .Replace(Loc.GetString("doc-var-name"), idCard.Comp.FullName ?? Loc.GetString("doc-text-printer-default-name"))
+            .Replace(Loc.GetString("doc-var-job"), idCard.Comp.LocalizedJobTitle ?? Loc.GetString("doc-text-printer-default-job"));
+        }
+
+        var printed = Spawn("Paper", Transform(ent).Coordinates);
+
+        if (HasComp<PaperComponent>(printed))
+        {
+            _paperSystem.SetContent(printed, content);
+            _audio.PlayPvs(new SoundPathSpecifier("/Audio/Machines/printer.ogg"), ent);
+        }
     }
 
     private void OnAddHistory(Entity<CriminalRecordsConsoleComponent> ent, ref CriminalRecordAddHistory msg)
@@ -373,10 +467,24 @@ public sealed partial class CriminalRecordsConsoleSystem : SharedCriminalRecords
         if (!_criminalRecords.TryGetHistory(key.Value, msg.Index, out var crimeHistory))
             return;
 
+        if (crimeHistory.Value.Status is null)
+            return;
+
         if (!_records.TryGetRecord<GeneralStationRecord>(key.Value, out var entry))
             return;
 
-        PrintDocument(ent, msg.Actor, entry, crimeHistory.Value.Articles, crimeHistory.Value.Duration);
+        switch (crimeHistory.Value.Status.Value)
+        {
+            case SecurityStatus.Detained:
+                PrintDetainedDocument(ent, msg.Actor, entry, crimeHistory.Value.Articles, crimeHistory.Value.Duration);
+                break;
+            case SecurityStatus.Wanted:
+                PrintWantedDocument(ent, msg.Actor, entry);
+                break;
+            default:
+                break;
+        }
+
         ent.Comp.NextPrintTime = _timing.CurTime + ent.Comp.PrintCooldown;
         Dirty(ent);
     }

--- a/Content.Server/CriminalRecords/Systems/CriminalRecordsSystem.cs
+++ b/Content.Server/CriminalRecords/Systems/CriminalRecordsSystem.cs
@@ -112,9 +112,9 @@ public sealed class CriminalRecordsSystem : SharedCriminalRecordsSystem
     /// <summary>
     /// Creates and tries to add a history entry using the current time.
     /// </summary>
-    public bool TryAddHistory(StationRecordKey key, string line, string? initiatorName = null, string? articles = null, int? duration = null) // CorvaxGoob-SecurityFeatures
+    public bool TryAddHistory(StationRecordKey key, string line, string? initiatorName = null, string? articles = null, int? duration = null, SecurityStatus? status = null) // CorvaxGoob-SecurityFeatures
     {
-        var entry = new CrimeHistory(_ticker.RoundDuration(), line, initiatorName, articles, duration); // CorvaxGoob-SecurityFeatures
+        var entry = new CrimeHistory(_ticker.RoundDuration(), line, initiatorName, articles, duration, status); // CorvaxGoob-SecurityFeatures
         return TryAddHistory(key, entry);
     }
 

--- a/Content.Server/CriminalRecords/Systems/WantedMenuSystem.cs
+++ b/Content.Server/CriminalRecords/Systems/WantedMenuSystem.cs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Content.Server.StationRecords;
 using Content.Shared.Access.Components;
 using Content.Shared.CriminalRecords;
-using Content.Shared.CriminalRecords.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Security;
 using Content.Shared.StationRecords;
@@ -204,7 +202,7 @@ public sealed partial class CriminalRecordsConsoleSystem
 
         // CorvaxGoob-SecurityFeatures-Start
         var history = Loc.GetString("criminal-records-console-detained-record", ("articles", articles ?? Loc.GetString("criminal-records-console-unspecified")), ("duration", msg.Duration?.ToString() ?? Loc.GetString("criminal-records-console-unspecified")));
-        _criminalRecords.TryAddHistory(key.Value, history, officer, articles, msg.Duration);
+        _criminalRecords.TryAddHistory(key.Value, history, officer, articles, msg.Duration, SecurityStatus.Detained);
         // CorvaxGoob-SecurityFeatures-End
 
         // will probably never fail given the checks above

--- a/Content.Shared/CriminalRecords/Components/CriminalRecordsConsoleComponent.cs
+++ b/Content.Shared/CriminalRecords/Components/CriminalRecordsConsoleComponent.cs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Shared.CriminalRecords.Systems;
-using Content.Shared.CriminalRecords.Components;
-using Content.Shared.CriminalRecords;
 using Content.Shared.Radio;
 using Content.Shared.StationRecords;
 using Robust.Shared.Prototypes;

--- a/Content.Shared/CriminalRecords/CriminalRecord.cs
+++ b/Content.Shared/CriminalRecords/CriminalRecord.cs
@@ -43,4 +43,4 @@ public sealed partial record CriminalRecord
 /// A line of criminal activity and the time it was added at.
 /// </summary>
 [Serializable, NetSerializable]
-public record struct CrimeHistory(TimeSpan AddTime, string Crime, string? InitiatorName, string? Articles = null, int? Duration = null); // CorvaxGoob-SecurityFeatures
+public record struct CrimeHistory(TimeSpan AddTime, string Crime, string? InitiatorName, string? Articles = null, int? Duration = null, SecurityStatus? Status = null); // CorvaxGoob-SecurityFeatures

--- a/Content.Shared/CriminalRecords/CriminalRecordsUi.cs
+++ b/Content.Shared/CriminalRecords/CriminalRecordsUi.cs
@@ -91,6 +91,19 @@ public sealed class CriminalRecordChangeDetainedStatus : BoundUserInterfaceMessa
     }
 }
 
+// CorvaxGoob-SecurityFeatures
+[Serializable, NetSerializable]
+public sealed class CriminalRecordChangeWantedStatus : BoundUserInterfaceMessage
+{
+    public readonly string? Reason;
+    public readonly bool Print;
+    public CriminalRecordChangeWantedStatus(string? reason, bool print = false)
+    {
+        Reason = reason;
+        Print = print;
+    }
+}
+
 /// <summary>
 /// Used to add a single line to the record's crime history.
 /// </summary>

--- a/Resources/Locale/ru-RU/_CorvaxGoob/criminal-records/criminal-records.ftl
+++ b/Resources/Locale/ru-RU/_CorvaxGoob/criminal-records/criminal-records.ftl
@@ -1,6 +1,6 @@
 criminal-records-console-initiator = Инициатор
 
-criminal-records-console-detained-record = Арестован: { $articles } | СРОК: { $duration } мин
+criminal-records-console-detained-record = Арестован по: { $articles } | СРОК: { $duration } мин
 criminal-records-console-detained-reason = Арестован по причине
 
 criminal-records-console-history = { $status }: { $reason }

--- a/Resources/Locale/ru-RU/_CorvaxGoob/criminal-records/criminal-records.ftl
+++ b/Resources/Locale/ru-RU/_CorvaxGoob/criminal-records/criminal-records.ftl
@@ -1,7 +1,9 @@
 criminal-records-console-initiator = Инициатор
 
-criminal-records-console-detained-record = НАРУШЕНО: { $articles } | СРОК: { $duration } мин
+criminal-records-console-detained-record = Арестован: { $articles } | СРОК: { $duration } мин
 criminal-records-console-detained-reason = Арестован по причине
+
+criminal-records-console-history = { $status }: { $reason }
 
 criminal-records-console-unspecified = <не указано>
 
@@ -12,3 +14,4 @@ criminal-records-console-duration = Срок (мин.)
 criminal-records-console-duration-placeholder = Пример: 10
 
 criminal-records-console-print = Распечатать
+


### PR DESCRIPTION
## Описание PR
Ряд изменений прошлого ПРа на изменение конслоль криминальных записей:

* В историю записываются все изменения статуса.
* При добавлении статуса "Розыск", можно на месте распечатать документ "ОБВИНИТЕЛЬНОЕ ЗАКЛЮЧЕНИЕ"
* Исправлены мелкие баги

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.