### PR TITLE
[fix] shader

### DIFF
--- a/Content.Client/Singularity/SingularityOverlay.cs
+++ b/Content.Client/Singularity/SingularityOverlay.cs
@@ -25,6 +25,9 @@ namespace Content.Client.Singularity
 
         private const float MaxDistance = 20f;
 
+        private const float MinDistance = 1f;// Corvaxgoob-fix
+        private const float MaxDeformation = 2048f; // Corvaxgoob-fix
+
         public override OverlaySpace Space => OverlaySpace.WorldSpace;
         public override bool RequestScreenTexture => true;
 
@@ -122,7 +125,9 @@ namespace Content.Client.Singularity
                 var localPosition = _positions[i];
                 localPosition.Y = args.Viewport.Size.Y - localPosition.Y;
                 var delta = args.VisiblePosition - localPosition;
-                var distance = (delta / (args.Viewport.RenderScale * args.Viewport.Eye.Scale)).Length();
+                var distance = MathF.Max(
+                    (delta / (args.Viewport.RenderScale * args.Viewport.Eye.Scale)).Length(),
+                    MinDistance); // Corvaxgoob-fix
 
                 var deformation = _intensities[i] / MathF.Pow(distance, _falloffPowers[i]);
 
@@ -136,6 +141,8 @@ namespace Content.Client.Singularity
 
                 if (deformation > 0.8)
                     deformation = MathF.Pow(deformation, 0.3f);
+
+                deformation = MathF.Min(deformation, MaxDeformation); // Corvaxgoob-fix
 
                 finalCoords -= delta * deformation;
             }

--- a/Resources/Textures/Shaders/singularity.swsl
+++ b/Resources/Textures/Shaders/singularity.swsl
@@ -8,9 +8,12 @@ uniform lowp int count;
 uniform highp float[5] falloffPower;
 uniform highp float[5] intensity;
 uniform highp vec2[5] position;
-// the `5`s in the array lengths correspond to the upper limit on the simultaneous distortion sources that can be present on screen at a time. 
+// the `5`s in the array lengths correspond to the upper limit on the simultaneous distortion sources that can be present on screen at a time.
 // If you want to change this, make sure to change all of them here, in the for loop, and, in whatever overlay assigns the uniforms
 // (apparently #define is an unknown preprocessor directive)
+
+const highp float MIN_DISTANCE = 1.0; // Corvaxgoob-fix
+const highp float MAX_DEFORMATION = 2048.0; // Corvaxgoob-fix
 
 void fragment() {
 
@@ -18,28 +21,30 @@ void fragment() {
     highp vec2 delta;
     highp float distance;
     highp float deformation;
-    
+
     for (int i = 0; i < 5 && i < count; i++) {
-    
+
         delta = FRAGCOORD.xy - position[i];
-	    distance = length(delta / renderScale);
+	    distance = max(length(delta / renderScale), MIN_DISTANCE); // Corvaxgoob-fix
 
         deformation = intensity[i] / pow(distance, falloffPower[i]);
-        
+
         // ensure deformation goes to zero at max distance
         // avoids long-range single-pixel shifts that are noticeable when leaving PVS.
-        
+
         if (distance >= maxDistance) {
             deformation = 0.0;
         } else {
             deformation *= (1.0 - pow(distance/maxDistance, 4.0));
         }
-        
+
         if(deformation > 0.8)
             deformation = pow(deformation, 0.3);
 
+        deformation = min(deformation, MAX_DEFORMATION); // Corvaxgoob-fix
+
         finalCoords -= deformation * delta;
     }
-    
+
     COLOR = zTextureSpec(SCREEN_TEXTURE, finalCoords*SCREEN_PIXEL_SIZE );
 }


### PR DESCRIPTION
## Описание PR
Исправление возникновения серого экрана у всех на карте, вроде рабочее. Теперь шейдер не будет пытаться в деление на 0 и выкидывание это в ПВЗ, который оказывается не имеет лимита.
Другие шейдеры оценочно не зависят от пользователя и не так опасны, и, самое главное, я теперь знаю трассу ошибки. Да, фикс избыточный, но кто мне запретит.