### PR TITLE
[FIX] Обновление манифеста при повторном открытии КПК

### DIFF
--- a/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
+++ b/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Client.CartridgeLoader.Cartridges; // CorvaxGoob - fix-crew-manifest-open-refresh-v2
 using Content.Client.UserInterface.Fragments;
 using Content.Shared.CartridgeLoader;
 using Robust.Client.UserInterface;
@@ -41,6 +42,17 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
 
         var activeUI = _entManager.GetEntity(loaderUiState.ActiveUI);
 
+        // CorvaxGoob Start - fix-crew-manifest-open-refresh-v2
+        // A reopened PDA can reuse its BUI, so refresh the attached manifest without recreating its controls.
+        if (_activeProgram == activeUI && _activeUiFragment is not null)
+        {
+            if (_activeCartridgeUI is CrewManifestUi && _activeProgram.HasValue)
+                SendCartridgeUiReadyEvent(_activeProgram.Value);
+
+            return;
+        }
+        // CorvaxGoob End
+
         _activeProgram = activeUI;
 
         var ui = RetrieveCartridgeUI(activeUI);
@@ -48,8 +60,8 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
         var control = ui?.GetUIFragmentRoot();
 
         //Prevent the same UI fragment from getting disposed and attached multiple times
-        if (_activeUiFragment?.GetType() == control?.GetType())
-            return;
+        //if (_activeUiFragment?.GetType() == control?.GetType())
+        //    return;
 
         if (_activeUiFragment is not null)
             DetachCartridgeUI(_activeUiFragment);

--- a/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
@@ -59,7 +59,7 @@ public sealed class CrewManifestCartridgeSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
-        var owningStation = _stationSystem.GetOwningStation(uid);
+        var owningStation = _stationSystem.GetOwningStation(loaderUid); // CorvaxGoob Edit - fix-crew-manifest-open-refresh-v2
 
         if (owningStation is null)
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
<!-- Что вы изменили? -->
Исправлено обновление манифеста при повторном открытии КПК.
> _Не уверен, что это 100% источник бага. Так как на сервере грид обычно не менялся, а список всё равно был пустым._

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Открытая программа манифеста в КПК могла показывать пустой список, пока не осуществить перезапуск программы.

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Станция определяется по КПК.
При повторном открытии КПК существующий интерфейс манифеста не пересоздаётся, но клиент повторно отправляет `UIReady`.
#fix-crew-manifest-open-refresh-v2

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

До:

https://github.com/user-attachments/assets/c6e215de-bf5f-4d7e-981c-e0f60ca3983a

После:

https://github.com/user-attachments/assets/994bc0d3-e36a-4959-9752-f6f8b652ded2


## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
—

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:

- fix: Исправлено обновление списка экипажа в программе 'Манифест' при повторном открытии интерфейса КПК.
