### PR TITLE
Печать медицинского отчёта анализатором здоровья

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerBoundUserInterface.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerBoundUserInterface.cs
@@ -3,6 +3,9 @@
 using Content.Shared.MedicalScanner;
 using Content.Shared._Shitmed.Targeting; // Shitmed Change
 using Content.Shared._Shitmed.Medical.HealthAnalyzer; // Shitmed Change
+// CorvaxGoob start
+using Content.Shared._CorvaxGoob.Medical.HealthAnalyzer;
+// CorvaxGoob end
 using JetBrains.Annotations;
 using Robust.Client.UserInterface;
 
@@ -25,6 +28,9 @@ namespace Content.Client.HealthAnalyzer.UI
             _window = this.CreateWindow<HealthAnalyzerWindow>();
             _window.OnBodyPartSelected += SendBodyPartMessage; // Shitmed Change
             _window.OnModeChanged += SendModeMessage;
+            // CorvaxGoob start
+            _window.PrintButton.OnPressed += _ => SendMessage(new HealthAnalyzerPrintMessage());
+            // CorvaxGoob end
             _window.Title = EntMan.GetComponent<MetaDataComponent>(Owner).EntityName;
         }
 

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
@@ -37,7 +37,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             <Button
                 Name="PrintButton"
                 Access="Public"
-                Text="Печать отчёта"
+                Text="{Loc 'health-analyzer-print-button'}"
                 MinWidth="150"
                 MinHeight="30"
                 HorizontalExpand="True"

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
@@ -26,13 +26,23 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                 MinHeight="30"
                 HorizontalExpand="True"
                 StyleClasses="OpenBoth"/>
+            <!-- CorvaxGoob start -->
             <Button
                 Name="ChemicalsButton"
                 Text="{Loc 'health-analyzer-window-chemicals'}"
                 MinWidth="130"
                 MinHeight="30"
                 HorizontalExpand="True"
+                StyleClasses="OpenBoth"/>
+            <Button
+                Name="PrintButton"
+                Access="Public"
+                Text="Печать отчёта"
+                MinWidth="150"
+                MinHeight="30"
+                HorizontalExpand="True"
                 StyleClasses="OpenLeft"/>
+            <!-- CorvaxGoob end -->
         </BoxContainer>
         <PanelContainer StyleClasses="LowDivider"/>
         <BoxContainer Orientation="Horizontal" VerticalExpand="True">

--- a/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
+++ b/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
@@ -3,6 +3,9 @@
 using Robust.Shared.Audio;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using Content.Shared._Shitmed.Medical.HealthAnalyzer;
+// CorvaxGoob start
+using Content.Server._CorvaxGoob.Medical;
+// CorvaxGoob end
 
 namespace Content.Server.Medical.Components;
 
@@ -13,7 +16,9 @@ namespace Content.Server.Medical.Components;
 /// Requires <c>ItemToggleComponent</c>.
 /// </remarks>
 [RegisterComponent, AutoGenerateComponentPause]
-[Access(typeof(HealthAnalyzerSystem), typeof(CryoPodSystem))]
+// CorvaxGoob start
+[Access(typeof(HealthAnalyzerSystem), typeof(HealthAnalyzerPrintSystem), typeof(CryoPodSystem))]
+// CorvaxGoob end
 public sealed partial class HealthAnalyzerComponent : Component
 {
     /// <summary>

--- a/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
+++ b/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
@@ -81,4 +81,18 @@ public sealed partial class HealthAnalyzerComponent : Component
     /// </summary>
     [DataField]
     public HealthAnalyzerMode CurrentMode = HealthAnalyzerMode.Body;
+
+    // CorvaxGoob start
+    /// <summary>
+    /// When will the analyzer be ready to print another medical report?
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan PrintReadyAt = TimeSpan.Zero;
+
+    /// <summary>
+    /// How often can the analyzer print medical reports?
+    /// </summary>
+    [DataField]
+    public TimeSpan PrintCooldown = TimeSpan.FromSeconds(5);
+    // CorvaxGoob end
 }

--- a/Content.Server/_CorvaxGoob/Medical/HealthAnalyzerPrintSystem.cs
+++ b/Content.Server/_CorvaxGoob/Medical/HealthAnalyzerPrintSystem.cs
@@ -74,6 +74,15 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
 
     private void OnPrint(Entity<HealthAnalyzerComponent> analyzer, ref HealthAnalyzerPrintMessage args)
     {
+        if (_timing.CurTime < analyzer.Comp.PrintReadyAt)
+        {
+            _popupSystem.PopupEntity(
+                Loc.GetString("health-analyzer-report-printer-not-ready"),
+                analyzer.Owner,
+                args.Actor);
+            return;
+        }
+
         if (analyzer.Comp.ScannedEntity is not { } target || Deleted(target))
         {
             _popupSystem.PopupEntity(Loc.GetString("health-analyzer-report-no-patient"), analyzer.Owner, args.Actor);
@@ -105,6 +114,8 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
                 .WithVolume(3f)
                 .WithRolloffFactor(2.8f)
                 .WithMaxDistance(4.5f));
+
+        analyzer.Comp.PrintReadyAt = _timing.CurTime + analyzer.Comp.PrintCooldown;
     }
 
     private string BuildReport(EntityUid target, BodyComponent body)

--- a/Content.Server/_CorvaxGoob/Medical/HealthAnalyzerPrintSystem.cs
+++ b/Content.Server/_CorvaxGoob/Medical/HealthAnalyzerPrintSystem.cs
@@ -1,0 +1,467 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+using System.Text;
+using Content.Goobstation.Shared.Disease.Components;
+using Content.Server.Body.Systems;
+using Content.Server.Medical.Components;
+using Content.Shared._CorvaxGoob.Medical.HealthAnalyzer;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
+using Content.Shared._Shitmed.Medical.Surgery.Wounds;
+using Content.Shared._Shitmed.Medical.Surgery.Wounds.Systems;
+using Content.Shared._Shitmed.Targeting;
+using Content.Shared.Atmos.Rotting;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Part;
+using Content.Shared.Body.Systems;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Humanoid;
+using Content.Shared.Humanoid.Prototypes;
+using Content.Shared.MedicalScanner;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Paper;
+using Content.Shared.Popups;
+using Content.Shared.Temperature.Components;
+using Content.Shared.Traits.Assorted;
+using Robust.Server.GameObjects;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Server._CorvaxGoob.Medical;
+
+/// <summary>
+/// Prints a receipt-style snapshot of the patient currently scanned by a health analyzer.
+/// </summary>
+public sealed class HealthAnalyzerPrintSystem : EntitySystem
+{
+    private static readonly SoundSpecifier PrintSound = new SoundPathSpecifier("/Audio/Machines/diagnoser_printing.ogg");
+
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly PaperSystem _paperSystem = default!;
+    [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+    [Dependency] private readonly MetaDataSystem _metaData = default!;
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
+    [Dependency] private readonly BloodstreamSystem _bloodstreamSystem = default!;
+    [Dependency] private readonly SharedBodySystem _bodySystem = default!;
+    [Dependency] private readonly WoundSystem _woundSystem = default!;
+    [Dependency] private readonly TraumaSystem _traumaSystem = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
+    [Dependency] private readonly MobThresholdSystem _threshold = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        Subs.BuiEvents<HealthAnalyzerComponent>(HealthAnalyzerUiKey.Key, subs =>
+        {
+            subs.Event<HealthAnalyzerPrintMessage>(OnPrint);
+        });
+    }
+
+    private void OnPrint(Entity<HealthAnalyzerComponent> analyzer, ref HealthAnalyzerPrintMessage args)
+    {
+        if (analyzer.Comp.ScannedEntity is not { } target || Deleted(target))
+        {
+            _popupSystem.PopupEntity("Нет данных пациента для печати.", analyzer.Owner, args.Actor);
+            return;
+        }
+
+        if (!TryComp<BodyComponent>(target, out var body))
+        {
+            _popupSystem.PopupEntity("Не удалось получить медицинские данные пациента.", analyzer.Owner, args.Actor);
+            return;
+        }
+
+        var printed = Spawn("MedicalReportPaper", Transform(analyzer.Owner).Coordinates);
+        _handsSystem.PickupOrDrop(args.Actor, printed, checkActionBlocker: false);
+
+        if (!TryComp<PaperComponent>(printed, out var paper))
+        {
+            Log.Error("Health analyzer printed an entity without PaperComponent.");
+            return;
+        }
+
+        var patientName = MetaData(target).EntityName;
+        _metaData.SetEntityName(printed, $"Медицинский отчёт — {patientName}");
+        _paperSystem.SetContent((printed, paper), BuildReport(target, body));
+
+        _audioSystem.PlayPvs(PrintSound, analyzer.Owner,
+            AudioParams.Default
+                .WithVariation(0.25f)
+                .WithVolume(3f)
+                .WithRolloffFactor(2.8f)
+                .WithMaxDistance(4.5f));
+    }
+
+    private string BuildReport(EntityUid target, BodyComponent body)
+    {
+        var text = new StringBuilder();
+        var patientName = MetaData(target).EntityName;
+
+        text.AppendLine("МЕДИЦИНСКИЙ ОТЧЁТ");
+        text.AppendLine();
+        text.AppendLine($"Пациент: {patientName}");
+        text.AppendLine(GetPatientTypeName(target));
+        text.AppendLine($"Время сканирования: {_timing.CurTime:hh\\:mm\\:ss}");
+
+        var status = Loc.GetString("health-analyzer-window-entity-unknown-text");
+        if (TryComp<MobStateComponent>(target, out var mobState))
+        {
+            status = mobState.CurrentState switch
+            {
+                MobState.Alive => Colorize(Loc.GetString("health-analyzer-window-entity-alive-text"), "#2E7D32"),
+                MobState.Critical => Colorize(Loc.GetString("health-analyzer-window-entity-critical-text"), "#B8860B"),
+                MobState.Dead => Colorize(Loc.GetString("health-analyzer-window-entity-dead-text"), "#C62828"),
+                _ => status,
+            };
+        }
+
+        text.AppendLine($"Статус: {status}");
+
+        if (TryComp<TemperatureComponent>(target, out var temperature))
+            text.AppendLine($"Температура: {temperature.CurrentTemperature - 273.15f:F1} °C ({temperature.CurrentTemperature:F1} K)");
+
+        var bloodLevel = _bloodstreamSystem.GetBloodLevel(target);
+        text.AppendLine($"Уровень крови: {bloodLevel * 100f:F1} %");
+
+        AppendDamage(text, target);
+        AppendBodyCondition(text, target, body, bloodLevel);
+        AppendDiseases(text, target);
+        AppendOrgans(text, target);
+        AppendChemicals(text, target, body);
+
+        return text.ToString();
+    }
+
+    private string GetPatientTypeName(EntityUid target)
+    {
+        if (TryComp<HumanoidAppearanceComponent>(target, out var humanoid) &&
+            _prototypes.TryIndex<SpeciesPrototype>(humanoid.Species, out var species))
+        {
+            return Loc.GetString(species.Name);
+        }
+
+        var prototypeName = MetaData(target).EntityPrototype?.Name;
+        return string.IsNullOrWhiteSpace(prototypeName)
+            ? Loc.GetString("health-analyzer-window-entity-unknown-species-text")
+            : prototypeName;
+    }
+
+    private void AppendDamage(StringBuilder text, EntityUid target)
+    {
+        text.AppendLine();
+        text.AppendLine("ПОВРЕЖДЕНИЯ:");
+
+        if (!TryComp<DamageableComponent>(target, out var damageable))
+        {
+            text.AppendLine("Повреждений: 0");
+            return;
+        }
+
+        var hasDamage = damageable.Damage.DamageDict.Any(entry => entry.Value > 0);
+        if (!hasDamage)
+        {
+            text.AppendLine("Повреждений: 0");
+            return;
+        }
+
+        text.AppendLine($"Общие повреждения: {damageable.TotalDamage}");
+        text.AppendLine($"Суммарный урон: {_threshold.CheckVitalDamage(target, damageable)}");
+
+        foreach (var (damageTypeId, amount) in damageable.Damage.DamageDict.OrderByDescending(x => x.Value))
+        {
+            if (amount <= 0)
+                continue;
+
+            var name = damageTypeId;
+            if (_prototypes.TryIndex<DamageTypePrototype>(damageTypeId, out var prototype))
+                name = prototype.LocalizedName;
+
+            var damageLine = Loc.GetString(
+                "health-analyzer-window-damage-type-text",
+                ("damageType", name),
+                ("amount", amount));
+
+            text.AppendLine(Colorize($"- {damageLine}", GetDamageColor(damageTypeId)));
+        }
+    }
+
+    private void AppendBodyCondition(StringBuilder text, EntityUid target, BodyComponent body, float bloodLevel)
+    {
+        text.AppendLine();
+        text.AppendLine("СОСТОЯНИЕ:");
+
+        var any = false;
+        var patientName = MetaData(target).EntityName;
+
+        if (TryComp<BloodstreamComponent>(target, out var bloodstream) && bloodLevel < bloodstream.BloodlossThreshold)
+        {
+            any = true;
+            text.AppendLine(Colorize(
+                Loc.GetString("condition-body-low-blood", ("entity", patientName)),
+                "#C62828"));
+        }
+
+        if (TryComp<UnrevivableComponent>(target, out var unrevivable) && unrevivable.Analyzable)
+        {
+            any = true;
+            text.AppendLine(Loc.GetString("condition-body-unrevivable", ("entity", patientName)));
+        }
+
+        if (body.RootContainer.ContainedEntity is { } rootPart)
+        {
+            var woundables = _woundSystem.GetAllWoundableChildren(rootPart).ToList();
+
+            foreach (var (woundable, woundableComp) in woundables)
+            {
+                if (woundableComp.Bleeds <= 0)
+                    continue;
+
+                any = true;
+                var bodyPart = _bodySystem.GetTargetBodyPart(woundable);
+                text.AppendLine(Loc.GetString(
+                    $"condition-body-bleeding-{bodyPart}",
+                    ("entity", patientName)));
+            }
+
+            foreach (var (woundable, _) in woundables)
+            {
+                if (!_traumaSystem.TryGetWoundableTrauma(woundable, out var traumas))
+                    continue;
+
+                foreach (var trauma in traumas)
+                {
+                    var traumaType = trauma.Comp.TraumaType.ToString();
+
+                    // Dismemberment is represented below by the actual missing body part.
+                    // Organ damage is represented in the organs section by its integrity percentage.
+                    if (traumaType is "Dismemberment" or "OrganDamage")
+                        continue;
+
+                    any = true;
+                    var woundableName = MetaData(woundable).EntityName;
+
+                    if (trauma.Comp.TraumaType == TraumaSystem.BoneDamage &&
+                        trauma.Comp.TraumaTarget is { } bone &&
+                        TryComp<BoneComponent>(bone, out var boneComp))
+                    {
+                        text.AppendLine(Loc.GetString(
+                            $"condition-body-trauma-BoneDamage-{boneComp.BoneSeverity}",
+                            ("woundable", woundableName)));
+                        continue;
+                    }
+
+                    text.AppendLine(Loc.GetString(
+                        $"condition-body-trauma-{traumaType}",
+                        ("woundable", woundableName)));
+                }
+            }
+        }
+
+        if (HasComp<TargetingComponent>(target))
+        {
+            var bodyState = _woundSystem.GetDamageableStatesOnBody(target);
+            var severedParts = bodyState
+                .Where(entry => entry.Value == WoundableSeverity.Severed)
+                .Select(entry => entry.Key)
+                .ToHashSet();
+
+            foreach (var part in severedParts)
+            {
+                if (part is TargetBodyPart.Chest or TargetBodyPart.Groin)
+                    continue;
+
+                if (part == TargetBodyPart.LeftHand && severedParts.Contains(TargetBodyPart.LeftArm) ||
+                    part == TargetBodyPart.RightHand && severedParts.Contains(TargetBodyPart.RightArm) ||
+                    part == TargetBodyPart.LeftFoot && severedParts.Contains(TargetBodyPart.LeftLeg) ||
+                    part == TargetBodyPart.RightFoot && severedParts.Contains(TargetBodyPart.RightLeg))
+                {
+                    continue;
+                }
+
+                any = true;
+                text.AppendLine($"• {GetRussianBodyPartName(part)}: отсутствует");
+            }
+        }
+
+        if (!any)
+            text.AppendLine(Loc.GetString("condition-none"));
+    }
+
+    private void AppendDiseases(StringBuilder text, EntityUid target)
+    {
+        if (!TryComp<DiseaseCarrierComponent>(target, out var carrier) || carrier.Diseases.ContainedEntities.Count == 0)
+            return;
+
+        var first = true;
+        foreach (var diseaseUid in carrier.Diseases.ContainedEntities)
+        {
+            if (!TryComp<DiseaseComponent>(diseaseUid, out var disease))
+                continue;
+
+            text.AppendLine();
+            if (!first)
+                text.AppendLine("---");
+
+            first = false;
+            text.AppendLine(Loc.GetString(
+                "health-analyzer-window-disease-type-text",
+                ("type", disease.Genotype)));
+            text.AppendLine(Loc.GetString(
+                "health-analyzer-window-disease-progress-text",
+                ("progress", disease.InfectionProgress)));
+            text.AppendLine(Loc.GetString(
+                "health-analyzer-window-immunity-progress-text",
+                ("progress", disease.ImmunityProgress)));
+        }
+    }
+
+    private void AppendOrgans(StringBuilder text, EntityUid target)
+    {
+        text.AppendLine();
+        text.AppendLine("ОРГАНЫ:");
+
+        var any = false;
+        foreach (var (organUid, organComp) in _bodySystem.GetBodyOrgans(target))
+        {
+            if (organComp.IntegrityCap <= 0)
+                continue;
+
+            any = true;
+            var organName = MetaData(organUid).EntityName;
+            var percent = organComp.OrganIntegrity / organComp.IntegrityCap * 100;
+
+            text.AppendLine($"- {Loc.GetString(
+                "group-organ-status",
+                ("organ", organName),
+                ("capacity", percent))}");
+
+            if (HasComp<RottingComponent>(organUid))
+                text.AppendLine(Loc.GetString("condition-organ-rotting", ("organ", organName)));
+        }
+
+        if (!any)
+            text.AppendLine("Не обнаружено.");
+    }
+
+    private void AppendChemicals(StringBuilder text, EntityUid target, BodyComponent body)
+    {
+        text.AppendLine();
+        text.AppendLine("ХИМИКАТЫ:");
+
+        var any = false;
+
+        if (TryComp(target, out SolutionContainerManagerComponent? container))
+        {
+            foreach (var (name, solution) in _solutionContainerSystem.EnumerateSolutions((target, container)))
+            {
+                if (name is null ||
+                    name == BloodstreamComponent.DefaultBloodTemporarySolutionName ||
+                    name == "print")
+                    continue;
+
+                if (AppendSolution(text, solution.Comp.Solution))
+                    any = true;
+            }
+        }
+
+        if (_bodySystem.TryGetBodyOrganEntityComps<StomachComponent>((target, body), out var stomachs))
+        {
+            foreach (var stomach in stomachs)
+            {
+                if (stomach.Comp1.Solution is null)
+                    continue;
+
+                if (AppendSolution(text, stomach.Comp1.Solution.Value.Comp.Solution))
+                    any = true;
+            }
+        }
+
+        if (!any)
+            text.AppendLine("Не обнаружено.");
+    }
+
+    private bool AppendSolution(StringBuilder text, Solution solution)
+    {
+        var reagents = solution.Contents.Where(x => x.Quantity > 0).ToList();
+        if (reagents.Count == 0)
+            return false;
+
+        var solutionName = solution.Name is { } name
+            ? Loc.GetString("group-solution-name", ("solution", Loc.GetString($"solution-type-{name}")))
+            : Loc.GetString("group-solution-unknown");
+
+        text.AppendLine($"{solutionName}:");
+        foreach (var reagent in reagents)
+        {
+            var reagentName = reagent.Reagent.Prototype;
+            if (_prototypes.TryIndex<ReagentPrototype>(reagent.Reagent.Prototype, out var prototype))
+                reagentName = prototype.LocalizedName;
+
+            text.AppendLine($"- {Loc.GetString(
+                "group-solution-contents",
+                ("reagent", reagentName),
+                ("quantity", reagent.Quantity))}");
+        }
+
+        return true;
+    }
+
+    private static string Colorize(string text, string? color)
+    {
+        return color is null ? text : $"[color={color}]{text}[/color]";
+    }
+
+    private static string? GetDamageColor(string damageTypeId)
+    {
+        return damageTypeId.ToLowerInvariant() switch
+        {
+            "blunt" => "#A93226",
+            "slash" => "#C0392B",
+            "piercing" => "#922B21",
+            "heat" => "#D35400",
+            "cold" => "#2874A6",
+            "shock" => "#B7950B",
+            "caustic" => "#6C8E23",
+            "asphyxiation" => "#5D6D7E",
+            "bloodloss" => "#B03A2E",
+            "poison" => "#1E8449",
+            "radiation" => "#7D3C98",
+            "cellular" => "#884EA0",
+            "structural" => "#616A6B",
+            _ => null,
+        };
+    }
+
+    private static string GetRussianBodyPartName(TargetBodyPart part)
+    {
+        return part switch
+        {
+            TargetBodyPart.Head => "Голова",
+            TargetBodyPart.Chest => "Грудь",
+            TargetBodyPart.Groin => "Пах",
+            TargetBodyPart.LeftArm => "Левая рука",
+            TargetBodyPart.LeftHand => "Левая кисть",
+            TargetBodyPart.RightArm => "Правая рука",
+            TargetBodyPart.RightHand => "Правая кисть",
+            TargetBodyPart.LeftLeg => "Левая нога",
+            TargetBodyPart.LeftFoot => "Левая стопа",
+            TargetBodyPart.RightLeg => "Правая нога",
+            TargetBodyPart.RightFoot => "Правая стопа",
+            _ => part.ToString(),
+        };
+    }
+}

--- a/Content.Server/_CorvaxGoob/Medical/HealthAnalyzerPrintSystem.cs
+++ b/Content.Server/_CorvaxGoob/Medical/HealthAnalyzerPrintSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Hands.EntitySystems;

--- a/Content.Server/_CorvaxGoob/Medical/HealthAnalyzerPrintSystem.cs
+++ b/Content.Server/_CorvaxGoob/Medical/HealthAnalyzerPrintSystem.cs
@@ -255,8 +255,8 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
                 any = true;
                 var bodyPart = _bodySystem.GetTargetBodyPart(woundable);
                 text.AppendLine(Loc.GetString(
-                    $"condition-body-bleeding-{bodyPart}",
-                    ("entity", patientName)));
+                    "health-analyzer-report-bleeding-part",
+                    ("part", GetBodyPartName(bodyPart))));
             }
 
             foreach (var (woundable, _) in woundables)
@@ -274,7 +274,7 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
                         continue;
 
                     any = true;
-                    var woundableName = MetaData(woundable).EntityName;
+                    var woundableName = GetBodyPartName(_bodySystem.GetTargetBodyPart(woundable));
 
                     if (trauma.Comp.TraumaType == TraumaSystem.BoneDamage &&
                         trauma.Comp.TraumaTarget is { } bone &&

--- a/Content.Server/_CorvaxGoob/Medical/HealthAnalyzerPrintSystem.cs
+++ b/Content.Server/_CorvaxGoob/Medical/HealthAnalyzerPrintSystem.cs
@@ -75,13 +75,13 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
     {
         if (analyzer.Comp.ScannedEntity is not { } target || Deleted(target))
         {
-            _popupSystem.PopupEntity("Нет данных пациента для печати.", analyzer.Owner, args.Actor);
+            _popupSystem.PopupEntity(Loc.GetString("health-analyzer-report-no-patient"), analyzer.Owner, args.Actor);
             return;
         }
 
         if (!TryComp<BodyComponent>(target, out var body))
         {
-            _popupSystem.PopupEntity("Не удалось получить медицинские данные пациента.", analyzer.Owner, args.Actor);
+            _popupSystem.PopupEntity(Loc.GetString("health-analyzer-report-no-medical-data"), analyzer.Owner, args.Actor);
             return;
         }
 
@@ -95,7 +95,7 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
         }
 
         var patientName = MetaData(target).EntityName;
-        _metaData.SetEntityName(printed, $"Медицинский отчёт — {patientName}");
+        _metaData.SetEntityName(printed, Loc.GetString("health-analyzer-report-paper-name", ("patient", patientName)));
         _paperSystem.SetContent((printed, paper), BuildReport(target, body));
 
         _audioSystem.PlayPvs(PrintSound, analyzer.Owner,
@@ -110,12 +110,13 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
     {
         var text = new StringBuilder();
         var patientName = MetaData(target).EntityName;
+        var scanTime = _timing.CurTime.ToString(@"hh\:mm\:ss");
 
-        text.AppendLine("МЕДИЦИНСКИЙ ОТЧЁТ");
+        text.AppendLine(Loc.GetString("health-analyzer-report-title"));
         text.AppendLine();
-        text.AppendLine($"Пациент: {patientName}");
+        text.AppendLine(Loc.GetString("health-analyzer-report-patient", ("patient", patientName)));
         text.AppendLine(GetPatientTypeName(target));
-        text.AppendLine($"Время сканирования: {_timing.CurTime:hh\\:mm\\:ss}");
+        text.AppendLine(Loc.GetString("health-analyzer-report-scan-time", ("time", scanTime)));
 
         var status = Loc.GetString("health-analyzer-window-entity-unknown-text");
         if (TryComp<MobStateComponent>(target, out var mobState))
@@ -129,13 +130,18 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
             };
         }
 
-        text.AppendLine($"Статус: {status}");
+        text.AppendLine(Loc.GetString("health-analyzer-report-status", ("status", status)));
 
         if (TryComp<TemperatureComponent>(target, out var temperature))
-            text.AppendLine($"Температура: {temperature.CurrentTemperature - 273.15f:F1} °C ({temperature.CurrentTemperature:F1} K)");
+        {
+            text.AppendLine(Loc.GetString(
+                "health-analyzer-report-temperature",
+                ("celsius", $"{temperature.CurrentTemperature - 273.15f:F1}"),
+                ("kelvin", $"{temperature.CurrentTemperature:F1}")));
+        }
 
         var bloodLevel = _bloodstreamSystem.GetBloodLevel(target);
-        text.AppendLine($"Уровень крови: {bloodLevel * 100f:F1} %");
+        text.AppendLine(Loc.GetString("health-analyzer-report-blood-level", ("level", $"{bloodLevel * 100f:F1}")));
 
         AppendDamage(text, target);
         AppendBodyCondition(text, target, body, bloodLevel);
@@ -163,23 +169,27 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
     private void AppendDamage(StringBuilder text, EntityUid target)
     {
         text.AppendLine();
-        text.AppendLine("ПОВРЕЖДЕНИЯ:");
+        text.AppendLine(Loc.GetString("health-analyzer-report-damage-heading"));
 
         if (!TryComp<DamageableComponent>(target, out var damageable))
         {
-            text.AppendLine("Повреждений: 0");
+            text.AppendLine(Loc.GetString("health-analyzer-report-no-damage"));
             return;
         }
 
         var hasDamage = damageable.Damage.DamageDict.Any(entry => entry.Value > 0);
         if (!hasDamage)
         {
-            text.AppendLine("Повреждений: 0");
+            text.AppendLine(Loc.GetString("health-analyzer-report-no-damage"));
             return;
         }
 
-        text.AppendLine($"Общие повреждения: {damageable.TotalDamage}");
-        text.AppendLine($"Суммарный урон: {_threshold.CheckVitalDamage(target, damageable)}");
+        text.AppendLine(Loc.GetString(
+            "health-analyzer-report-total-damage",
+            ("damage", damageable.TotalDamage.ToString())));
+        text.AppendLine(Loc.GetString(
+            "health-analyzer-report-vital-damage",
+            ("damage", _threshold.CheckVitalDamage(target, damageable).ToString())));
 
         foreach (var (damageTypeId, amount) in damageable.Damage.DamageDict.OrderByDescending(x => x.Value))
         {
@@ -202,7 +212,7 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
     private void AppendBodyCondition(StringBuilder text, EntityUid target, BodyComponent body, float bloodLevel)
     {
         text.AppendLine();
-        text.AppendLine("СОСТОЯНИЕ:");
+        text.AppendLine(Loc.GetString("health-analyzer-report-condition-heading"));
 
         var any = false;
         var patientName = MetaData(target).EntityName;
@@ -293,7 +303,9 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
                 }
 
                 any = true;
-                text.AppendLine($"• {GetRussianBodyPartName(part)}: отсутствует");
+                text.AppendLine(Loc.GetString(
+                    "health-analyzer-report-missing-part",
+                    ("part", GetBodyPartName(part))));
             }
         }
 
@@ -332,7 +344,7 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
     private void AppendOrgans(StringBuilder text, EntityUid target)
     {
         text.AppendLine();
-        text.AppendLine("ОРГАНЫ:");
+        text.AppendLine(Loc.GetString("health-analyzer-report-organs-heading"));
 
         var any = false;
         foreach (var (organUid, organComp) in _bodySystem.GetBodyOrgans(target))
@@ -354,13 +366,13 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
         }
 
         if (!any)
-            text.AppendLine("Не обнаружено.");
+            text.AppendLine(Loc.GetString("health-analyzer-report-none"));
     }
 
     private void AppendChemicals(StringBuilder text, EntityUid target, BodyComponent body)
     {
         text.AppendLine();
-        text.AppendLine("ХИМИКАТЫ:");
+        text.AppendLine(Loc.GetString("health-analyzer-report-chemicals-heading"));
 
         var any = false;
 
@@ -391,7 +403,7 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
         }
 
         if (!any)
-            text.AppendLine("Не обнаружено.");
+            text.AppendLine(Loc.GetString("health-analyzer-report-none"));
     }
 
     private bool AppendSolution(StringBuilder text, Solution solution)
@@ -420,6 +432,27 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
         return true;
     }
 
+    private string GetBodyPartName(TargetBodyPart part)
+    {
+        var locKey = part switch
+        {
+            TargetBodyPart.Head => "health-analyzer-report-body-part-head",
+            TargetBodyPart.Chest => "health-analyzer-report-body-part-chest",
+            TargetBodyPart.Groin => "health-analyzer-report-body-part-groin",
+            TargetBodyPart.LeftArm => "health-analyzer-report-body-part-left-arm",
+            TargetBodyPart.LeftHand => "health-analyzer-report-body-part-left-hand",
+            TargetBodyPart.RightArm => "health-analyzer-report-body-part-right-arm",
+            TargetBodyPart.RightHand => "health-analyzer-report-body-part-right-hand",
+            TargetBodyPart.LeftLeg => "health-analyzer-report-body-part-left-leg",
+            TargetBodyPart.LeftFoot => "health-analyzer-report-body-part-left-foot",
+            TargetBodyPart.RightLeg => "health-analyzer-report-body-part-right-leg",
+            TargetBodyPart.RightFoot => "health-analyzer-report-body-part-right-foot",
+            _ => null,
+        };
+
+        return locKey is null ? part.ToString() : Loc.GetString(locKey);
+    }
+
     private static string Colorize(string text, string? color)
     {
         return color is null ? text : $"[color={color}]{text}[/color]";
@@ -443,25 +476,6 @@ public sealed class HealthAnalyzerPrintSystem : EntitySystem
             "cellular" => "#884EA0",
             "structural" => "#616A6B",
             _ => null,
-        };
-    }
-
-    private static string GetRussianBodyPartName(TargetBodyPart part)
-    {
-        return part switch
-        {
-            TargetBodyPart.Head => "Голова",
-            TargetBodyPart.Chest => "Грудь",
-            TargetBodyPart.Groin => "Пах",
-            TargetBodyPart.LeftArm => "Левая рука",
-            TargetBodyPart.LeftHand => "Левая кисть",
-            TargetBodyPart.RightArm => "Правая рука",
-            TargetBodyPart.RightHand => "Правая кисть",
-            TargetBodyPart.LeftLeg => "Левая нога",
-            TargetBodyPart.LeftFoot => "Левая стопа",
-            TargetBodyPart.RightLeg => "Правая нога",
-            TargetBodyPart.RightFoot => "Правая стопа",
-            _ => part.ToString(),
         };
     }
 }

--- a/Content.Shared/_CorvaxGoob/Medical/HealthAnalyzer/HealthAnalyzerPrintMessage.cs
+++ b/Content.Shared/_CorvaxGoob/Medical/HealthAnalyzer/HealthAnalyzerPrintMessage.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CorvaxGoob.Medical.HealthAnalyzer;
+
+/// <summary>
+/// Requests a printable report for the patient currently scanned by a health analyzer.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class HealthAnalyzerPrintMessage : BoundUserInterfaceMessage
+{
+}

--- a/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-report.ftl
+++ b/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-report.ftl
@@ -1,0 +1,38 @@
+health-analyzer-print-button = Print report
+
+health-analyzer-report-no-patient = No patient data to print.
+health-analyzer-report-no-medical-data = Unable to retrieve patient medical data.
+health-analyzer-report-paper-name = Medical report — {$patient}
+
+health-analyzer-report-title = MEDICAL REPORT
+health-analyzer-report-patient = {$patient}
+health-analyzer-report-scan-time = Scan time: {$time}
+health-analyzer-report-status = Status: {$status}
+health-analyzer-report-temperature = Temperature: {$celsius} °C ({$kelvin} K)
+health-analyzer-report-blood-level = Blood level: {$level} %
+
+health-analyzer-report-damage-heading = DAMAGE:
+health-analyzer-report-no-damage = Damage: 0
+health-analyzer-report-total-damage = Total damage: {$damage}
+health-analyzer-report-vital-damage = Cumulative damage: {$damage}
+
+health-analyzer-report-condition-heading = CONDITION:
+health-analyzer-report-organs-heading = ORGANS:
+health-analyzer-report-chemicals-heading = CHEMICALS:
+health-analyzer-report-none = None detected.
+health-analyzer-report-missing-part = • {$part}: missing
+
+health-analyzer-report-body-part-head = Head
+health-analyzer-report-body-part-chest = Chest
+health-analyzer-report-body-part-groin = Groin
+health-analyzer-report-body-part-left-arm = Left arm
+health-analyzer-report-body-part-left-hand = Left hand
+health-analyzer-report-body-part-right-arm = Right arm
+health-analyzer-report-body-part-right-hand = Right hand
+health-analyzer-report-body-part-left-leg = Left leg
+health-analyzer-report-body-part-left-foot = Left foot
+health-analyzer-report-body-part-right-leg = Right leg
+health-analyzer-report-body-part-right-foot = Right foot
+
+ent-MedicalReportPaper = medical report
+    .desc = A medical report printed by a health analyzer.

--- a/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-report.ftl
+++ b/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-report.ftl
@@ -2,6 +2,7 @@ health-analyzer-print-button = Print report
 
 health-analyzer-report-no-patient = No patient data to print.
 health-analyzer-report-no-medical-data = Unable to retrieve patient medical data.
+health-analyzer-report-printer-not-ready = The printer is not ready to print another report yet.
 health-analyzer-report-paper-name = Medical report — {$patient}
 
 health-analyzer-report-title = MEDICAL REPORT

--- a/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-report.ftl
+++ b/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-report.ftl
@@ -22,6 +22,7 @@ health-analyzer-report-organs-heading = ORGANS:
 health-analyzer-report-chemicals-heading = CHEMICALS:
 health-analyzer-report-none = None detected.
 health-analyzer-report-missing-part = • {$part}: missing
+health-analyzer-report-bleeding-part = • {$part}: bleeding
 
 health-analyzer-report-body-part-head = Head
 health-analyzer-report-body-part-chest = Chest

--- a/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-report.ftl
+++ b/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-report.ftl
@@ -3,7 +3,7 @@ health-analyzer-print-button = Print report
 health-analyzer-report-no-patient = No patient data to print.
 health-analyzer-report-no-medical-data = Unable to retrieve patient medical data.
 health-analyzer-report-printer-not-ready = The printer is not ready to print another report yet.
-health-analyzer-report-paper-name = Medical report — {$patient}
+health-analyzer-report-paper-name = medical report — {$patient}
 
 health-analyzer-report-title = MEDICAL REPORT
 health-analyzer-report-patient = {$patient}

--- a/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-report.ftl
+++ b/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-report.ftl
@@ -12,7 +12,7 @@ health-analyzer-report-temperature = Temperature: {$celsius} °C ({$kelvin} K)
 health-analyzer-report-blood-level = Blood level: {$level} %
 
 health-analyzer-report-damage-heading = DAMAGE:
-health-analyzer-report-no-damage = Damage: 0
+health-analyzer-report-no-damage = No damage.
 health-analyzer-report-total-damage = Total Damage: {$damage}
 health-analyzer-report-vital-damage = Cumulative damage: {$damage}
 

--- a/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-report.ftl
+++ b/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-report.ftl
@@ -13,7 +13,7 @@ health-analyzer-report-blood-level = Blood level: {$level} %
 
 health-analyzer-report-damage-heading = DAMAGE:
 health-analyzer-report-no-damage = Damage: 0
-health-analyzer-report-total-damage = Total damage: {$damage}
+health-analyzer-report-total-damage = Total Damage: {$damage}
 health-analyzer-report-vital-damage = Cumulative damage: {$damage}
 
 health-analyzer-report-condition-heading = CONDITION:

--- a/Resources/Locale/ru-RU/_CorvaxGoob/medical/health-analyzer-report.ftl
+++ b/Resources/Locale/ru-RU/_CorvaxGoob/medical/health-analyzer-report.ftl
@@ -1,0 +1,38 @@
+health-analyzer-print-button = Печать отчёта
+
+health-analyzer-report-no-patient = Нет данных пациента для печати.
+health-analyzer-report-no-medical-data = Не удалось получить медицинские данные пациента.
+health-analyzer-report-paper-name = Медицинский отчёт — {$patient}
+
+health-analyzer-report-title = МЕДИЦИНСКИЙ ОТЧЁТ
+health-analyzer-report-patient = {$patient}
+health-analyzer-report-scan-time = Время сканирования: {$time}
+health-analyzer-report-status = Статус: {$status}
+health-analyzer-report-temperature = Температура: {$celsius} °C ({$kelvin} K)
+health-analyzer-report-blood-level = Уровень крови: {$level} %
+
+health-analyzer-report-damage-heading = ПОВРЕЖДЕНИЯ:
+health-analyzer-report-no-damage = Повреждений: 0
+health-analyzer-report-total-damage = Общие повреждения: {$damage}
+health-analyzer-report-vital-damage = Суммарный урон: {$damage}
+
+health-analyzer-report-condition-heading = СОСТОЯНИЕ:
+health-analyzer-report-organs-heading = ОРГАНЫ:
+health-analyzer-report-chemicals-heading = ХИМИКАТЫ:
+health-analyzer-report-none = Не обнаружено.
+health-analyzer-report-missing-part = • {$part}: отсутствует
+
+health-analyzer-report-body-part-head = Голова
+health-analyzer-report-body-part-chest = Грудь
+health-analyzer-report-body-part-groin = Пах
+health-analyzer-report-body-part-left-arm = Левая рука
+health-analyzer-report-body-part-left-hand = Левая кисть
+health-analyzer-report-body-part-right-arm = Правая рука
+health-analyzer-report-body-part-right-hand = Правая кисть
+health-analyzer-report-body-part-left-leg = Левая нога
+health-analyzer-report-body-part-left-foot = Левая стопа
+health-analyzer-report-body-part-right-leg = Правая нога
+health-analyzer-report-body-part-right-foot = Правая стопа
+
+ent-MedicalReportPaper = медицинский отчёт
+    .desc = Медицинский отчёт, напечатанный анализатором здоровья.

--- a/Resources/Locale/ru-RU/_CorvaxGoob/medical/health-analyzer-report.ftl
+++ b/Resources/Locale/ru-RU/_CorvaxGoob/medical/health-analyzer-report.ftl
@@ -3,7 +3,7 @@ health-analyzer-print-button = Печать отчёта
 health-analyzer-report-no-patient = Нет данных пациента для печати.
 health-analyzer-report-no-medical-data = Не удалось получить медицинские данные пациента.
 health-analyzer-report-printer-not-ready = Принтер ещё не готов к повторной печати.
-health-analyzer-report-paper-name = Медицинский отчёт — {$patient}
+health-analyzer-report-paper-name = медицинский отчёт — {$patient}
 
 health-analyzer-report-title = МЕДИЦИНСКИЙ ОТЧЁТ
 health-analyzer-report-patient = {$patient}

--- a/Resources/Locale/ru-RU/_CorvaxGoob/medical/health-analyzer-report.ftl
+++ b/Resources/Locale/ru-RU/_CorvaxGoob/medical/health-analyzer-report.ftl
@@ -2,6 +2,7 @@ health-analyzer-print-button = Печать отчёта
 
 health-analyzer-report-no-patient = Нет данных пациента для печати.
 health-analyzer-report-no-medical-data = Не удалось получить медицинские данные пациента.
+health-analyzer-report-printer-not-ready = Принтер ещё не готов к повторной печати.
 health-analyzer-report-paper-name = Медицинский отчёт — {$patient}
 
 health-analyzer-report-title = МЕДИЦИНСКИЙ ОТЧЁТ

--- a/Resources/Locale/ru-RU/_CorvaxGoob/medical/health-analyzer-report.ftl
+++ b/Resources/Locale/ru-RU/_CorvaxGoob/medical/health-analyzer-report.ftl
@@ -12,7 +12,7 @@ health-analyzer-report-temperature = Температура: {$celsius} °C ({$k
 health-analyzer-report-blood-level = Уровень крови: {$level} %
 
 health-analyzer-report-damage-heading = ПОВРЕЖДЕНИЯ:
-health-analyzer-report-no-damage = Повреждений: 0
+health-analyzer-report-no-damage = Повреждений нет.
 health-analyzer-report-total-damage = Общие повреждения: {$damage}
 health-analyzer-report-vital-damage = Суммарный урон: {$damage}
 

--- a/Resources/Locale/ru-RU/_CorvaxGoob/medical/health-analyzer-report.ftl
+++ b/Resources/Locale/ru-RU/_CorvaxGoob/medical/health-analyzer-report.ftl
@@ -22,6 +22,7 @@ health-analyzer-report-organs-heading = ОРГАНЫ:
 health-analyzer-report-chemicals-heading = ХИМИКАТЫ:
 health-analyzer-report-none = Не обнаружено.
 health-analyzer-report-missing-part = • {$part}: отсутствует
+health-analyzer-report-bleeding-part = • {$part}: кровотечение
 
 health-analyzer-report-body-part-head = Голова
 health-analyzer-report-body-part-chest = Грудь

--- a/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Specific/Medical/medical_report.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Specific/Medical/medical_report.yml
@@ -3,8 +3,6 @@
 - type: entity
   id: MedicalReportPaper
   parent: Paper
-  name: медицинский отчёт
-  description: Медицинский отчёт, напечатанный анализатором здоровья.
   components:
   - type: Sprite
     sprite: Objects/Misc/bureaucracy.rsi

--- a/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Specific/Medical/medical_report.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Specific/Medical/medical_report.yml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: entity
+  id: MedicalReportPaper
+  parent: Paper
+  name: медицинский отчёт
+  description: Медицинский отчёт, напечатанный анализатором здоровья.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/bureaucracy.rsi
+    layers:
+    - state: paper_receipt
+    - state: paper_receipt_words
+      map: ["enum.PaperVisualLayers.Writing"]
+      visible: false
+    - state: paper_stamp-generic
+      map: ["enum.PaperVisualLayers.Stamp"]
+      visible: false
+  - type: PaperVisuals
+    backgroundImagePath: "/Textures/Interface/Paper/paper_background_perforated.svg.96dpi.png"
+    backgroundImageTile: true
+    backgroundPatchMargin: 0.0, 6.0, 0.0, 6.0
+    contentMargin: 12.0, 0.0, 12.0, 0.0
+    maxWritableArea: 256.0, 0.0


### PR DESCRIPTION
## Описание PR

Добавляет возможность распечатать результаты сканирования пациента через анализатор здоровья.

После сканирования в интерфейсе появляется кнопка «Печать отчёта». Анализатор печатает отдельный предмет «Медицинский отчёт» в формате чековой бумаги.

В отчёте указываются:
- имя пациента и время сканирования;
- состояние пациента, температура и уровень крови;
- общие повреждения, суммарный урон и типы повреждений;
- кровотечения, переломы, повреждения нервов/сосудов и отсутствующие конечности;
- информация о заболевании, если оно обнаружено;
- состояние органов;
- обнаруженные реагенты.

Дублирующая информация не выводится: повреждения органов остаются в разделе органов, а ампутации отображаются только как отсутствующая часть тела.

## Почему / Баланс

Позволяет сохранять результаты медицинского обследования в физическом виде. Отчёт можно использовать для медицинских карт, передачи информации между врачами и документирования состояния пациента без повторного сканирования.

На лечение и характеристики анализатора изменение не влияет.

## Технические детали

- Добавлена кнопка для печати результатов текущего сканирования.
- Добавлена серверная система формирования отчёта.
- Добавлен отдельный прототип `MedicalReportPaper` с чековым спрайтом.
- Используется звук печати диагностического сканера.
- Цветом выделяются статус пациента, низкий уровень крови и типы повреждений.
- Отчёт формируется из данных, доступных медицинскому анализатору.

## Медиа

<img width="987" height="637" alt="image" src="https://github.com/user-attachments/assets/2203b730-94ed-45e5-b626-12f62a5c51e9" />
<img width="318" height="991" alt="image" src="https://github.com/user-attachments/assets/ac71b3d9-1f87-4564-b514-b6d2e8df070f" />

- скрин открытого распечатанного медицинского отчёта.

## Требования

- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Критические изменения

Отсутствуют.

## Тестирование

Функция проверена в локалке. Финальная версия успешно компилируется и упаковывается.

**Список изменений**

:cl: Myakish
- add: Медицинский анализатор теперь может распечатать отчёт о состоянии просканированного пациента.
