### PR TITLE
Анализатор здоровья показывает незакрытые разрезы

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
@@ -34,6 +34,9 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
 using System.Globalization;
 using Content.Goobstation.Shared.Disease.Components;
+// CorvaxGoob start
+using Content.Shared._Shitmed.Medical.Surgery.Steps.Parts;
+// CorvaxGoob end
 
 namespace Content.Client.HealthAnalyzer.UI
 {
@@ -259,6 +262,25 @@ namespace Content.Client.HealthAnalyzer.UI
                     Text = Loc.GetString("condition-body-unrevivable", ("entity", Identity.Name(_target.Value, _entityManager))),
                     Margin = new Thickness(0, 4),
                 });
+
+            // CorvaxGoob start
+            foreach (var woundableNet in msg.Traumas.Keys)
+            {
+                if (isPart && woundableNet != msg.SelectedPart)
+                    continue;
+
+                var woundable = _entityManager.GetEntity(woundableNet);
+                if (!_entityManager.HasComponent<IncisionOpenComponent>(woundable)
+                    || !TryGetEntityName(woundableNet, out var woundableName))
+                    continue;
+
+                ConditionsListContainer.AddChild(new RichTextLabel
+                {
+                    Text = Loc.GetString("condition-body-open-incision", ("woundable", woundableName)),
+                    Margin = new Thickness(0, 4),
+                });
+            }
+            // CorvaxGoob end
 
             foreach (var (bodyPart, isBleeding) in msg.Bleeding)
             {

--- a/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-open-incision.ftl
+++ b/Resources/Locale/en-US/_CorvaxGoob/medical/health-analyzer-open-incision.ftl
@@ -1,0 +1,1 @@
+condition-body-open-incision = Open incision: {$woundable}

--- a/Resources/Locale/ru-RU/_CorvaxGoob/medical/health-analyzer-open-incision.ftl
+++ b/Resources/Locale/ru-RU/_CorvaxGoob/medical/health-analyzer-open-incision.ftl
@@ -1,0 +1,1 @@
+condition-body-open-incision = Незакрытый разрез: {$woundable}


### PR DESCRIPTION
## Описание PR

Анализатор здоровья теперь отображает незакрытые хирургические разрезы в разделе «Состояние».

Если на части тела присутствует открытый разрез, анализатор указывает конкретную часть тела, например:

- Незакрытый разрез: грудь
- Незакрытый разрез: левая рука

При просмотре отдельной части тела отображается только разрез на выбранной части. Если открытых разрезов нет, дополнительные строки не выводятся.

## Почему / Баланс

Незакрытый хирургический разрез является важной для врача информацией, однако ранее анализатор здоровья его не отображал.

Изменение позволяет быстро определить, остался ли после операции незакрытый разрез и где именно он находится, без необходимости вручную проверять каждую часть тела через хирургический интерфейс.

На лечение, характеристики анализатора и сами хирургические механики изменение не влияет.

## Технические детали

- Анализатор проверяет наличие существующего `IncisionOpenComponent` на частях тела пациента.
- Информация выводится в уже существующем разделе «Состояние».
- При просмотре всего тела отображаются все части с открытыми разрезами.
- При просмотре конкретной части тела отображается только её состояние.
- Добавлены локализации для ru-RU и en-US.
- Новые серверные сообщения и компоненты не добавлялись.

## Медиа
<img width="542" height="199" alt="image" src="https://github.com/user-attachments/assets/e6654c48-1cbc-498c-9ec8-c304d37daa7a" />


## Требования

- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Критические изменения

Отсутствуют.

**Список изменений**

:cl: Myakish
- add: Анализатор здоровья теперь показывает незакрытые хирургические разрезы пациента.