### PR TITLE
[FIX] Химмастер некорректно сохраняет температуру реагентов

### DIFF
--- a/Content.Server/Chemistry/Components/ChemMasterComponent.cs
+++ b/Content.Server/Chemistry/Components/ChemMasterComponent.cs
@@ -2,6 +2,9 @@
 
 using Content.Server.Chemistry.EntitySystems;
 using Content.Shared.Chemistry;
+// CorvaxGoob start
+using Content.Shared.Chemistry.Reagent;
+// CorvaxGoob end
 using Robust.Shared.Audio;
 
 namespace Content.Server.Chemistry.Components
@@ -34,5 +37,14 @@ namespace Content.Server.Chemistry.Components
         /// </summary>
         [DataField]
         public ChemMasterDrawSource DrawSource = ChemMasterDrawSource.Internal;
+
+        // CorvaxGoob start
+        /// <summary>
+        /// Temperatures stored independently for reagents in the internal buffer.
+        /// Reagents in a ChemMaster do not exchange heat until they are dispensed into a real solution.
+        /// </summary>
+        [ViewVariables]
+        public readonly Dictionary<ReagentId, float> BufferReagentTemperatures = new();
+        // CorvaxGoob end
     }
 }

--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -40,6 +40,9 @@ namespace Content.Server.Chemistry.EntitySystems
         [Dependency] private readonly StorageSystem _storageSystem = default!;
         [Dependency] private readonly LabelSystem _labelSystem = default!;
         [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+        // CorvaxGoob start
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        // CorvaxGoob end
 
         private static readonly EntProtoId PillPrototypeId = "Pill";
 
@@ -162,8 +165,19 @@ namespace Content.Server.Chemistry.EntitySystems
             if (fromBuffer) // Buffer to container
             {
                 amount = FixedPoint2.Min(amount, containerSolution.AvailableVolume);
+
+                // CorvaxGoob start
+                var sourceTemperature = GetBufferReagentTemperature(chemMaster.Comp, id, bufferSolution);
                 amount = bufferSolution.RemoveReagent(id, amount, preserveOrder: true);
-                _solutionContainerSystem.TryAddReagent(containerSoln.Value, id, amount, out var _);
+                if (amount <= FixedPoint2.Zero)
+                    return;
+
+                if (bufferSolution.GetReagentQuantity(id) <= FixedPoint2.Zero)
+                    chemMaster.Comp.BufferReagentTemperatures.Remove(id);
+
+                var transferredSolution = CreateReagentSolution(id, amount, sourceTemperature);
+                _solutionContainerSystem.TryAddSolution(containerSoln.Value, transferredSolution);
+                // CorvaxGoob end
             }
             else // Container to buffer
             {
@@ -171,8 +185,17 @@ namespace Content.Server.Chemistry.EntitySystems
                 if (bufferSolution.MaxVolume.Value > 0)    //Goobstation - chemicalbuffer if no limit
                     amount = FixedPoint2.Min(amount, containerSolution.GetReagentQuantity(id), bufferSolution.AvailableVolume);
 
-                _solutionContainerSystem.RemoveReagent(containerSoln.Value, id, amount);
+                // CorvaxGoob start
+                var sourceTemperature = containerSolution.Temperature;
+                var existingAmount = bufferSolution.GetReagentQuantity(id);
+
+                amount = _solutionContainerSystem.RemoveReagent(containerSoln.Value, id, amount);
+                if (amount <= FixedPoint2.Zero)
+                    return;
+
+                StoreBufferReagentTemperature(chemMaster.Comp, id, bufferSolution, existingAmount, amount, sourceTemperature);
                 bufferSolution.AddReagent(id, amount);
+                // CorvaxGoob end
             }
 
             if (actor.HasValue) // Goob - logging
@@ -189,7 +212,13 @@ namespace Content.Server.Chemistry.EntitySystems
             if (fromBuffer)
             {
                 if (_solutionContainerSystem.TryGetSolution(chemMaster.Owner, SharedChemMaster.BufferSolutionName, out _, out var bufferSolution))
+                {
+                    // CorvaxGoob start
                     bufferSolution.RemoveReagent(id, amount, preserveOrder: true);
+                    if (bufferSolution.GetReagentQuantity(id) <= FixedPoint2.Zero)
+                        chemMaster.Comp.BufferReagentTemperatures.Remove(id);
+                    // CorvaxGoob end
+                }
                 else
                     return;
             }
@@ -328,7 +357,10 @@ namespace Content.Server.Chemistry.EntitySystems
                         return false;
                     }
 
-                    break;
+                    // CorvaxGoob start
+                    outputSolution = WithdrawFromInternalBuffer(chemMaster.Comp, solution, neededVolume);
+                    return true;
+                    // CorvaxGoob end
 
                 case ChemMasterDrawSource.External:
                     if (_itemSlotsSystem.GetItemOrNull(chemMaster, SharedChemMaster.InputSlotName) is not {} container)
@@ -369,6 +401,72 @@ namespace Content.Server.Chemistry.EntitySystems
 
             return true;
         }
+
+        // CorvaxGoob start
+        private Solution WithdrawFromInternalBuffer(ChemMasterComponent chemMaster, Solution bufferSolution, FixedPoint2 amount)
+        {
+            var withdrawn = bufferSolution.SplitSolution(amount);
+            var output = new Solution();
+
+            foreach (var reagent in withdrawn.Contents)
+            {
+                var temperature = GetBufferReagentTemperature(chemMaster, reagent.Reagent, bufferSolution);
+                var portion = CreateReagentSolution(reagent.Reagent, reagent.Quantity, temperature);
+                output.AddSolution(portion, _prototypeManager);
+
+                if (bufferSolution.GetReagentQuantity(reagent.Reagent) <= FixedPoint2.Zero)
+                    chemMaster.BufferReagentTemperatures.Remove(reagent.Reagent);
+            }
+
+            return output;
+        }
+
+        private static Solution CreateReagentSolution(ReagentId id, FixedPoint2 amount, float temperature)
+        {
+            var solution = new Solution
+            {
+                Temperature = temperature,
+            };
+            solution.AddReagent(id, amount);
+            return solution;
+        }
+
+        private static float GetBufferReagentTemperature(ChemMasterComponent chemMaster, ReagentId id, Solution bufferSolution)
+        {
+            if (chemMaster.BufferReagentTemperatures.TryGetValue(id, out var temperature))
+                return temperature;
+
+            // Compatibility fallback for reagents inserted into the buffer by systems that do not track
+            // per-reagent temperature yet, such as existing automation paths.
+            temperature = bufferSolution.Temperature;
+            chemMaster.BufferReagentTemperatures[id] = temperature;
+            return temperature;
+        }
+
+        private static void StoreBufferReagentTemperature(
+            ChemMasterComponent chemMaster,
+            ReagentId id,
+            Solution bufferSolution,
+            FixedPoint2 existingAmount,
+            FixedPoint2 addedAmount,
+            float addedTemperature)
+        {
+            if (addedAmount <= FixedPoint2.Zero)
+                return;
+
+            if (existingAmount <= FixedPoint2.Zero)
+            {
+                chemMaster.BufferReagentTemperatures[id] = addedTemperature;
+                return;
+            }
+
+            var existingTemperature = GetBufferReagentTemperature(chemMaster, id, bufferSolution);
+            var totalAmount = existingAmount + addedAmount;
+            chemMaster.BufferReagentTemperatures[id] =
+                (existingTemperature * existingAmount.Float() + addedTemperature * addedAmount.Float()) /
+                totalAmount.Float();
+        }
+        // CorvaxGoob end
 
         private void ClickSound(Entity<ChemMasterComponent> chemMaster)
         {


### PR DESCRIPTION
## Описание PR

Исправляет работу температуры реагентов во внутреннем буфере химмастера. Сейчас можно нагреть небольшой объём реагента, отправить его в химмастер и дальше использовать сохранённую температуру при работе с другими реагентами которые поставляются из буфера. Из-за этого можно практически обойти нормальный нагрев растворов. После фикса химмастер запоминает температуру каждого реагента отдельно. Разные реагенты внутри буфера не обмениваются температурой в буфере. Температуры смешиваются только когда реагенты выводятся обратно в мензурку, бутылку или таблетку!!!

## Почему / Баланс

Исправляет абуз позволяющий практически бесплатно нагревать и охлаждать большие объёмы химикатов через химмастер. Например, 1u горячего реагента больше не позволяет поддерживать высокую температуру для всего содержимого буфера. Если раствор требует высокой температуры, нужно греть КАЖДЫЙ компонент до нужной температуры. Тоже самое касается и охлаждения. Данное решение создаст производство сложных лекарств сложнее, что снова откроет смысл в других не метовых химикатах, и добавит некую прогрессию в варке.
## Технические детали

- Температура хранится отдельно для каждого реагента в буфере химмастера.
- При добавлении того же реагента с другой температурой температура пересчитывается с учётом объёма.
- При выводе реагента используется сохранённая для него температура.
- Смешивание температур происходит уже в обычной ёмкости`.
- Работает при выводе в мензурки, бутылки и таблетки.

## Требования

- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Критические изменения

Добавлено публичное поле `BufferReagentTemperatures` в `ChemMasterComponent` для хранения температуры реагентов внутреннего буфера.

**Список изменений**

:cl: Myakish
- fix: Исправлен абуз температуры в химмастере. Небольшим объёмом реагента больше нельзя нагревать или охлаждать весь буфер, а температура реагентов теперь корректно учитывается при смешивании.