### PR TITLE
Нерф степаныча

### DIFF
--- a/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sniper_rifle.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sniper_rifle.yml
@@ -7,8 +7,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 50
+        Piercing: 40
       armorPenetration: 0.45
     penetrationThreshold: 100
   - type: StaminaDamageOnCollide
-    damage: 60
+    damage: 40


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Урон с пули степы был снижен с 50 --> 40, урон по стамине также был снижен с 60 до 40

## Почему / Баланс
Степан является одним из самых сильных пушек СБ, особенно из за огромного стамина дамага, его давненько стоило слегка таки понерфить.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- tweak: Изменено веселье