### PR TITLE
Реактор и турбина в шкафчике СИ

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -188,6 +188,7 @@
     - id: RCDRechargingCE
     - id: MaterialSiloFlatpack # Goob
     # Corvax Edit Start
+    - id: GasTurbineMonitorComputerCircuitboard
     - id: NuclearReactorMonitorComputerCircuitboard
     - id: SmallNuclearReactorFlatpack
     - id: GasTurbineSmallFlatpack

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -187,6 +187,11 @@
     - id: MachinePowerTransmissionLaserFlatpack
     - id: RCDRechargingCE
     - id: MaterialSiloFlatpack # Goob
+    # Corvax Edit Start
+    - id: NuclearReactorMonitorComputerCircuitboard
+    - id: SmallNuclearReactorFlatpack
+    - id: GasTurbineSmallFlatpack
+    # Corvax Edit End
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable


### PR DESCRIPTION
## Описание PR
Добавлены упаковки мини реактора и мини турбины в шкаф СИ.

## Почему / Баланс
Учитывая текущий способ добычи реактора, он неконкурентный аналог тэга: К тому моменту, как его закупят, источник питания на станции будет. Это изменение позволяет ему почти раундстартом быть запущенным в мини версии, с заделом на вырост при покупке большой версии.

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Критические изменения

**Список изменений**
Изменён лист спавна в шкафчике СИ.
:cl:
- add: Добавлены упаковка мини реактора, мини турбины и плата консоли мониторинга реактора.
