### PR TITLE
[FIX] Поправлен порядок вещей в поясах ученых и СИ

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -50,9 +50,11 @@
         - id: PowerDrill #CorvaxGoob: Fix order
         - id: WelderExperimental
         - id: Multitool
-        - id: HolofanProjector
+        - id: trayScanner #CorvaxGoob: Fix order
+        #- id: HolofanProjector #CorvaxGoob: Fix order
         - id: GasAnalyzer
-        - id: trayScanner
+        #- id: trayScanner #CorvaxGoob: Fix order
+        - id: HolofanProjector #CorvaxGoob: Fix order
 
 - type: entityTable
   id: BeltSecurityEntityTable

--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -26,6 +26,7 @@
       storagebase: !type:AllSelector
         children:
         #- id: CrowbarYellow #CorvaxGoob
+        - id: Crowbar #CorvaxGoob: CrowbarYellow --> Crowbar
         - id: Wrench
         - id: Screwdriver
         - id: Wirecutter
@@ -34,7 +35,6 @@
         #Goob-Station - changes made by Jellygato 7/13/24
         - id: trayScanner
         - id: GasAnalyzer
-        - id: Crowbar #CorvaxGoob: CrowbarYellow --> Crowbar
 
 - type: entity
   id: ClothingBeltChiefEngineerFilled
@@ -45,8 +45,9 @@
     containers:
       storagebase: !type:AllSelector
         children:
-        - id: PowerDrill
+        #- id: PowerDrill #CorvaxGoob: Fix order
         - id: JawsOfLife
+        - id: PowerDrill #CorvaxGoob: Fix order
         - id: WelderExperimental
         - id: Multitool
         - id: HolofanProjector


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Вернул старый порядок вещей в поясах

## Почему / Баланс
https://discord.com/channels/919301044784226385/1532806803476447323/1532806803476447323

## Технические детали
Поменял порядок вещей в yml

## Медиа
<img width="632" height="654" alt="Снимок экрана1" src="https://github.com/user-attachments/assets/4f58b0ef-d88d-4a9d-bdd5-5c03515bc600" />
<img width="645" height="752" alt="Снимок экрана2" src="https://github.com/user-attachments/assets/d1772d33-896e-4271-8381-0c339ae0bb97" />


## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl: Skarpelen
- fix: Исправлен съехавший порядок вещей в инженерно-научных поясах и поясе СИ
