### PR TITLE
[FIX] Исправление вечных ошибок в операциях автодока

### DIFF
--- a/Content.Shared/_CorvaxGoob/Autodoc/AutodocSurgeryCompletionSystem.cs
+++ b/Content.Shared/_CorvaxGoob/Autodoc/AutodocSurgeryCompletionSystem.cs
@@ -1,0 +1,108 @@
+using Content.Shared._Shitmed.Autodoc.Components;
+using Content.Shared._Shitmed.Medical.Surgery;
+using Content.Shared._Shitmed.Medical.Surgery.Conditions;
+using Content.Shared._Shitmed.Medical.Surgery.Steps;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Part;
+
+namespace Content.Shared._Shitmed.Autodoc.Systems;
+
+/// <summary>
+/// Завершает проблемные операции автодока и останавливает выполненные повторяемые шаги.
+/// </summary>
+public sealed class AutodocSurgeryCompletionSystem : EntitySystem
+{
+    [Dependency] private readonly SharedSurgerySystem _surgery = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<AutodocComponent, SurgeryStepEvent>(OnSurgeryStep);
+        SubscribeLocalEvent<BodyComponent, SurgeryDoAfterEvent>(OnSurgeryDoAfter, after: [typeof(SharedSurgerySystem)]);
+    }
+
+    private void OnSurgeryStep(Entity<AutodocComponent> ent, ref SurgeryStepEvent args)
+    {
+        if (!TryComp<ActiveAutodocComponent>(ent, out var active) ||
+            active.CurrentSurgery is not { } current)
+        {
+            return;
+        }
+
+        var (body, part, surgeryId) = current;
+
+        // Учитываем только последний шаг текущей корневой операции автодока
+        if (body != args.Body || part != args.Part ||
+            _surgery.GetSingleton(surgeryId) != args.Surgery ||
+            !TryComp(args.Surgery, out SurgeryComponent? surgery) ||
+            surgery.Steps.Count == 0 ||
+            _surgery.GetSingleton(surgery.Steps[^1]) != args.Step)
+        {
+            return;
+        }
+
+        // Не вмешиваемся в лечение костей, органов и ран и прочего
+        var removesPart = HasComp<SurgeryRemovePartStepComponent>(args.Step);
+        var removesOrgan = HasComp<SurgeryRemoveOrganStepComponent>(args.Step);
+        var attachesPart = HasComp<SurgeryAffixPartStepComponent>(args.Step) &&
+                           HasComp<SurgeryPartRemovedConditionComponent>(args.Surgery);
+        var attachesOrgan = HasComp<SurgeryAffixOrganStepComponent>(args.Step) &&
+                            TryComp(args.Surgery, out SurgeryOrganConditionComponent? organCondition) &&
+                            organCondition.Reattaching;
+
+        if (!removesPart && !removesOrgan && !attachesPart && !attachesOrgan)
+        {
+            return;
+        }
+
+        // После ампутации обычная проверка шага ненадежна, поскольку целевая часть уже отсоединена
+        if (removesPart)
+        {
+            if (TryComp(part, out BodyPartComponent? partComponent) &&
+                partComponent.Body == body)
+            {
+                return;
+            }
+        }
+        else if (!IsStepComplete(body, part, args.Surgery, args.Step))
+        {
+            return;
+        }
+
+        active.Waiting = false;
+        active.CurrentSurgery = null;
+        active.ProgramStep++;
+    }
+
+    private void OnSurgeryDoAfter(Entity<BodyComponent> ent, ref SurgeryDoAfterEvent args)
+    {
+        // Останавливаем повторение, если шаг активного автодока завершился после применения эффекта
+        if (args.Cancelled || !args.Repeat ||
+            args.Target is not { } part ||
+            !TryComp<ActiveAutodocComponent>(args.User, out var active) ||
+            active.CurrentSurgery is not { } current)
+        {
+            return;
+        }
+
+        var (body, currentPart, _) = current;
+
+        if (body != ent.Owner || currentPart != part ||
+            _surgery.GetSingleton(args.Surgery) is not { } surgery ||
+            _surgery.GetSingleton(args.Step) is not { } step ||
+            !IsStepComplete(body, part, surgery, step))
+        {
+            return;
+        }
+
+        args.Repeat = false;
+        active.Waiting = false;
+    }
+
+    private bool IsStepComplete(EntityUid body, EntityUid part, EntityUid surgery, EntityUid step)
+    {
+        var check = new SurgeryStepCompleteCheckEvent(body, part, surgery);
+        RaiseLocalEvent(step, ref check);
+        return !check.Cancelled;
+    }
+}

--- a/Content.Shared/_Shitmed/Autodoc/Components/ActiveAutodocComponent.cs
+++ b/Content.Shared/_Shitmed/Autodoc/Components/ActiveAutodocComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared._Shitmed.Autodoc.Components;
 /// Component added while operating on a patient.
 /// Only usable serverside, only thing that can be predicted is a surgery being active.
 /// </summary>
-[RegisterComponent, NetworkedComponent, Access(typeof(SharedAutodocSystem))]
+[RegisterComponent, NetworkedComponent, Access(typeof(SharedAutodocSystem), typeof(AutodocSurgeryCompletionSystem))] // CorvaxGoob - добавлен доступ для AutodocSurgeryCompletionSystem
 [AutoGenerateComponentPause]
 public sealed partial class ActiveAutodocComponent : Component
 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Автодок некорректно обрабатывал операции по удалению органов, ампутации конечностей, а так же присоединению конечностей

1. При удалении органов автодок доходит до шага с непосредственным удалением органа (после зажатия сосудов) и падает в ошибку. Требовалось перезапускать программу с этого же момента удаления органа чтобы автодок сразу начал удалять орган

2. При ампутации конечностей автодок, произведя ампутацию, начинал делать разрез на только что отрезанной конечности(операция на воздухе) и доходя до шага ее ампутации закономерно падал в ошибку. Решалось удалением в программе шага с ампутацией и перезапуском

3. При установке конечностей сразу после установки автодок начинал вновь открывать разрез на конечности-родителе чтобы вставить только что вставленный орган еще раз и падал когда не находил для него места. Решалось удалением в программе шага с установкой конечности и перезапуском

## Почему / Баланс
Это баги

## Технические детали
Щитхиругия определяет завершенность и необходимость повторения шага до применения эффекта шага. Поэтому после последнего выполнения повторяемого шага автодок мог остаться в состоянии ожидания и запустить лишнее повторение уже завершенного действия

Добавлен `AutodocSurgeryCompletionSystem`, который повторно проверяет завершенность шага и останавливает его повторение. Обработка применяется только к автодоку, ручная хирургия остается без изменений

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
https://cdn.discordapp.com/attachments/1541435550555443311/1541435716553150594/5dfa025ff53b5fca.mp4?ex=6a8d9561&is=6a8c43e1&hm=724d202f0b5913ce650b12aa6e5fddc72e6dae3f64eabbdd5361d42915148a9e&
https://discord.com/channels/919301044784226385/1541435550555443311/1541435550555443311

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl: Skarpelen
- fix: Автодок теперь корректно удаляет органы, ампутирует и присоединяет части тела.
