### PR TITLE
[FIX] Заполнитель медипенов теперь красит и маркирует медипены

### DIFF
--- a/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Specific/Medical/medipens.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Specific/Medical/medipens.yml
@@ -39,6 +39,7 @@
     solutionName: pen
     fillBaseName: medipen_solution-
     changeColor: true
+  - type: Medipen
   - type: Item
     sprite: _CorvaxGoob/Objects/Specific/Medical/medipen.rsi
     inhandVisuals:
@@ -95,6 +96,8 @@
     - state: microstimpen_empty_visual
       map: ["enum.MedipenColorLayer.Empty"]
       visible: false
+  - type: Medipen
+    label: component-microstimpen-default-label
   - type: SolutionContainerVisuals
     maxFillLevels: 1
     solutionName: pen


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Заполнитель медипенов не красит и не маркирует медипены из за ошибки при миграции, затерлись типы

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl: Skarpelen
- fix: Исправлен баг при котором заполнитель медипенов не красил и не маркировал медипены
