### PR TITLE
Нерф энерго-бол

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -104,3 +104,9 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
+  # CorvaxGoob start
+  - type: CombatDoAfter
+    trigger: !type:CombatDoAfterThrownEvent
+    delay: 5
+    dropCancelDelay: 0.005
+  # CorvaxGoob end


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Теперь энерго-болу нужно держать в руке при харм режиме 5 секунд, а не 1.5, что делает разоружение противников более проблематичным.

## Почему / Баланс
На данный момент бола является слишком простым орудием дизарма, что еще и замедляет тебя после попадания.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- tweak: Изменено КД для активации разоружения у энергобол

