### PR TITLE
Hardsuits rebalance

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1919,7 +1919,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndicate.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateHardsuitBundle
   cost:
-    Telecrystal: 50 # goob
+    Telecrystal: 30 # CorvaxGoob suits rabalance
   categories:
   - UplinkWearables
   #Goobstation
@@ -1928,7 +1928,25 @@
     blacklist:
       tags:
       - ContractorUplink
+      - NukeOpsUplink # CorvaxGoob suits rabalance
 
+ # CorvaxGoob suits rabalance start
+- type: listing
+  id: UplinkHardsuitSyndieNukeOps
+  name: uplink-hardsuit-syndie-name
+  description: uplink-hardsuit-syndie-desc
+  icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndicate.rsi, state: icon }
+  productEntity: ClothingBackpackDuffelSyndicateHardsuitBundle
+  cost:
+    Telecrystal: 50
+  categories:
+  - UplinkWearables
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+ # CorvaxGoob suits rabalance end
 
 - type: listing
   id: UplinkClothingOuterArmorRaid
@@ -1954,7 +1972,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   cost:
-    Telecrystal: 75 # goob
+    Telecrystal: 50 # CorvaxGoob suits rabalance
   categories:
   - UplinkWearables
   #Goobstation
@@ -1963,12 +1981,25 @@
     blacklist:
       tags:
       - ContractorUplink
-  #conditions: # Goobstation - no fuck you
-  #- !type:StoreWhitelistCondition
-  #  whitelist:
-  #    tags:
-  #    - NukeOpsUplink
+      - NukeOpsUplink # CorvaxGoob suits rabalance
 
+ # CorvaxGoob suits rabalance start
+- type: listing
+  id: UplinkHardsuitSyndieEliteNukeOps
+  name: uplink-hardsuit-syndieelite-name
+  description: uplink-hardsuit-syndieelite-desc
+  icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
+  productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
+  cost:
+    Telecrystal: 75
+  categories:
+  - UplinkWearables
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+ # CorvaxGoob suits rabalance end
 
 - type: listing
   id: UplinkClothingOuterHardsuitJuggernaut
@@ -1977,7 +2008,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/cybersun.rsi, state: icon } # goobstation - duke nukies
   productEntity: CrateCybersunJuggernautBundle
   cost:
-    Telecrystal: 75 # goob
+    Telecrystal: 50 # CorvaxGoob suits rabalance
   categories:
   - UplinkWearables
   #Goobstation
@@ -1986,12 +2017,25 @@
     blacklist:
       tags:
       - ContractorUplink
-  #conditions: # Goobstation - no fuck you
-  #- !type:StoreWhitelistCondition
-  # whitelist:
-  #    tags:
-  #    - NukeOpsUplink
+      - NukeOpsUplink # CorvaxGoob suits rabalance
 
+ # CorvaxGoob suits rabalance start
+- type: listing
+  id: UplinkClothingOuterHardsuitJuggernautNukeOps
+  name: uplink-clothing-outer-hardsuit-juggernaut-name
+  description: uplink-clothing-outer-hardsuit-juggernaut-desc
+  icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/cybersun.rsi, state: icon } # goobstation - duke nukies
+  productEntity: CrateCybersunJuggernautBundle
+  cost:
+    Telecrystal: 75
+  categories:
+  - UplinkWearables
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+ # CorvaxGoob suits rabalance end
 
 - type: listing
   id: UplinkClothingEyesHudSyndicate


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Цена элитки и джаги была снижена с 75 до 50 для агентов. Цена обычного кроваво-красного рига была снижена с 50 до 30 также для агентов. У оперативников она осталась прежней.

## Почему / Баланс
Абсолютно все скафандры в аплинке агента практически бесполезны из за своей конской цены, которая лишает их возможности взять какое либо адекватное вооружение, после покупки самого скафандра.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- tweak: Изменены цены на риги для агентуры
