### PR TITLE
[Fix] Medipens injection 

### DIFF
--- a/Resources/Prototypes/_CorvaxGoob/Chemistry/injector_modes.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Chemistry/injector_modes.yml
@@ -1,0 +1,4 @@
+- type: injectorMode
+  parent: [ BaseInstantHyposprayMode, BaseInjectMode ]
+  id: MedipenInjectMode
+  mobTime: 0.2

--- a/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Specific/Medical/medipens.yml
+++ b/Resources/Prototypes/_CorvaxGoob/Entities/Objects/Specific/Medical/medipens.yml
@@ -56,9 +56,9 @@
   - type: Injector
     solutionName: pen
     currentTransferAmount: 15
-    activeModeProtoId: HyposprayInjectMode
+    activeModeProtoId: MedipenInjectMode
     allowedModes:
-    - HyposprayInjectMode
+    - MedipenInjectMode
   - type: Appearance
   - type: PhysicalComposition
     materialComposition:
@@ -105,9 +105,9 @@
   - type: Injector
     solutionName: pen
     currentTransferAmount: 10
-    activeModeProtoId: HyposprayInjectMode
+    activeModeProtoId: MedipenInjectMode
     allowedModes:
-    - HyposprayInjectMode
+    - MedipenInjectMode
   - type: SolutionContainerManager
     solutions:
       pen:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Самодельные медипены снова имеют дуафтер на введение в 0.2 секунды. 

## Почему / Баланс
Без данного ограничения они являются одним из самых страшных орудий в игре, так как ты можешь буквально за секунду ввести в противника абсолютно что угодно. 

Ранее они имели ограничение, но оно было сломано после апстрима вроде как.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- fix: Исправлено отсутствие дуафтера у медипенов
