### PR TITLE
[ADD] Ядро ИИ теперь может взаимодействовать с консолью шаттла

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -474,6 +474,7 @@
     - HideContextMenu
     - StationAi
     - NoConsoleSound
+    - CanPilot # CorvaxGoob-AiShuttle
   - type: StartingMindRole
     mindRole: "MindRoleSiliconBrain"
     silent: true

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -133,6 +133,7 @@
   description: Used to pilot a shuttle.
   abstract: true
   components:
+  - type: StationAiWhitelist # CorvaxGoob-AiShuttle
   - type: DeviceLinkSink # CorvaxGoob-IIF-Improves
     ports:
       - ShuttleDroneReceiver


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
ИИ теперь может управлять шаттлами прямо из ядра, без необходимости переходить в тело борга

## Почему / Баланс
Я попытался сделать беспилотный шаттл с ядром ИИ на борту, прямо как у ксеноборгов, но столкнулся с суровой реальностью отсутствия ручек у ИИ

## Технические детали
Консоль управления шаттлом добавлена в вайтлист для ИИ чтобы он мог с ней взаимодействовать + ИИ мозг теперь может быть в режиме пилотирования

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl: Skarpelen
- add: Ядро ИИ теперь может взаимодействовать с консолью шаттла
