### PR TITLE
Криминальный статус при осмотре персонажа в очках СБ

### DIFF
--- a/Content.Server/_CorvaxGoob/CriminalRecords/CriminalRecordExamineSystem.cs
+++ b/Content.Server/_CorvaxGoob/CriminalRecords/CriminalRecordExamineSystem.cs
@@ -60,6 +60,7 @@ public sealed class CriminalRecordExamineSystem : EntitySystem
     {
         record = null;
 
+        // Stop if the target has no owning station or that station has no records storage.
         if (_station.GetOwningStation(target) is not { } station ||
             !TryComp<StationRecordsComponent>(station, out var stationRecords))
             return false;
@@ -101,15 +102,15 @@ public sealed class CriminalRecordExamineSystem : EntitySystem
         {
             SecurityStatus.Suspected => "#33CCCC",
             SecurityStatus.Wanted => "#ff0000",
-            SecurityStatus.Hostile => "#bd0000",
+            SecurityStatus.Hostile => "#bf0909",
             SecurityStatus.Detained => "#B18644",
             SecurityStatus.Paroled => "#7FB717",
             SecurityStatus.Discharged => "#288EFF",
             SecurityStatus.Eliminated => "#FFFFFF",
             SecurityStatus.Search => "#33CCCC",
             SecurityStatus.Perma => "#f29430",
-            SecurityStatus.Dangerous => "#9a0000",
-            SecurityStatus.Demote => "#e56359",
+            SecurityStatus.Dangerous => "#8e0202",
+            SecurityStatus.Demote => "#ed5146",
             _ => "#FFFFFF",
         };
     }

--- a/Content.Server/_CorvaxGoob/CriminalRecords/CriminalRecordExamineSystem.cs
+++ b/Content.Server/_CorvaxGoob/CriminalRecords/CriminalRecordExamineSystem.cs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Diagnostics.CodeAnalysis;
+using Content.Server.Station.Systems;
+using Content.Server.StationRecords.Systems;
+using Content.Shared.Access.Components;
+using Content.Shared.CriminalRecords;
+using Content.Shared.Examine;
+using Content.Shared.Inventory;
+using Content.Shared.Overlays;
+using Content.Shared.Security;
+using Content.Shared.StationRecords;
+using Robust.Shared.Utility;
+
+namespace Content.Server._CorvaxGoob.CriminalRecords;
+
+public sealed class CriminalRecordExamineSystem : EntitySystem
+{
+    [Dependency] private InventorySystem _inventory = default!;
+    [Dependency] private StationRecordsSystem _records = default!;
+    [Dependency] private StationSystem _station = default!;
+
+    private const int ExaminePriority = -100;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<IdExaminableComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(Entity<IdExaminableComponent> ent, ref ExaminedEvent args)
+    {
+        // Keep this server-side: full criminal records are stored in station records, not on the examined mob.
+        if (args.Examiner == ent.Owner || !HasSecurityHud(args.Examiner))
+            return;
+
+        if (!TryGetCriminalRecord(ent.Owner, out var record) ||
+            record.Status == SecurityStatus.None)
+            return;
+
+        var status = Loc.GetString($"criminal-records-status-{record.Status.ToString().ToLowerInvariant()}");
+        args.PushMessage(GetExamineMessage(record, status), ExaminePriority);
+    }
+
+    private bool HasSecurityHud(EntityUid user)
+    {
+        // Security cyber-eyes add this component directly to the body through Organ.onAdd.
+        if (HasComp<ShowCriminalRecordIconsComponent>(user))
+            return true;
+
+        // Worn SecHUD glasses keep the component on the item in the eyes slot.
+        return _inventory.TryGetSlotEntity(user, "eyes", out var eyes) &&
+               HasComp<ShowCriminalRecordIconsComponent>(eyes.Value);
+    }
+
+    private bool TryGetCriminalRecord(
+        EntityUid target,
+        [NotNullWhen(true)] out CriminalRecord? record)
+    {
+        record = null;
+
+        if (_station.GetOwningStation(target) is not { } station ||
+            !TryComp<StationRecordsComponent>(station, out var stationRecords))
+            return false;
+
+        // Match the existing glasses criminal records menu: the target record is resolved by station and entity name.
+        var name = MetaData(target).EntityName;
+        if (_records.GetRecordByName(station, name, stationRecords) is not { } id)
+            return false;
+
+        return _records.TryGetRecord<CriminalRecord>(
+            new StationRecordKey(id, station),
+            out record,
+            stationRecords);
+    }
+
+    private static FormattedMessage GetExamineMessage(CriminalRecord record, string status)
+    {
+        var message = new FormattedMessage();
+        var escapedStatus = FormattedMessage.EscapeText(status);
+
+        // Add a plain blank line between regular examine text and criminal record details.
+        message.PushNewline();
+
+        // Color only the status itself; the player-provided description below keeps normal examine coloring.
+        message.AddMarkupOrThrow($"[color={GetStatusColor(record.Status)}]{escapedStatus}[/color]");
+
+        if (!string.IsNullOrWhiteSpace(record.Reason))
+        {
+            message.PushNewline();
+            message.AddText($" - {FormattedMessage.EscapeText(record.Reason.Trim())}");
+        }
+
+        return message;
+    }
+
+    private static string GetStatusColor(SecurityStatus status)
+    {
+        return status switch
+        {
+            SecurityStatus.Suspected => "#33CCCC",
+            SecurityStatus.Wanted => "#ff0000",
+            SecurityStatus.Hostile => "#bd0000",
+            SecurityStatus.Detained => "#B18644",
+            SecurityStatus.Paroled => "#7FB717",
+            SecurityStatus.Discharged => "#288EFF",
+            SecurityStatus.Eliminated => "#FFFFFF",
+            SecurityStatus.Search => "#33CCCC",
+            SecurityStatus.Perma => "#f29430",
+            SecurityStatus.Dangerous => "#9a0000",
+            SecurityStatus.Demote => "#e56359",
+            _ => "#FFFFFF",
+        };
+    }
+}

--- a/Content.Server/_CorvaxGoob/CriminalRecords/CriminalRecordExamineSystem.cs
+++ b/Content.Server/_CorvaxGoob/CriminalRecords/CriminalRecordExamineSystem.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Server._CorvaxGoob.CriminalRecords;
 
+// #criminal-record-examine
 public sealed class CriminalRecordExamineSystem : EntitySystem
 {
     [Dependency] private InventorySystem _inventory = default!;

--- a/Content.Server/_CorvaxGoob/CriminalRecords/CriminalRecordExamineSystem.cs
+++ b/Content.Server/_CorvaxGoob/CriminalRecords/CriminalRecordExamineSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Examine;
 using Content.Shared.Inventory;
 using Content.Shared.Overlays;
 using Content.Shared.Security;
+using Content.Shared.Security.Components;
 using Content.Shared.StationRecords;
 using Robust.Shared.Utility;
 
@@ -34,6 +35,9 @@ public sealed class CriminalRecordExamineSystem : EntitySystem
     {
         // Keep this server-side: full criminal records are stored in station records, not on the examined mob.
         if (args.Examiner == ent.Owner || !HasSecurityHud(args.Examiner))
+            return;
+
+        if (!HasComp<CriminalRecordComponent>(ent.Owner))
             return;
 
         if (!TryGetCriminalRecord(ent.Owner, out var record) ||
@@ -116,3 +120,4 @@ public sealed class CriminalRecordExamineSystem : EntitySystem
         };
     }
 }
+


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
<!-- Что вы изменили? -->
При осмотре персонажа (через Shift+ЛКМ) с **HUD СБ** в окне осмотра отображаются название криминального статуса и указанная причина.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
QoL для быстрого принятия решения "здесь и сейчас" без открытия программы в КПК.
_КПК все еще будет полезен для просмотра списка всех криминальных личностей на станции._

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
- Расширение обычного `examine` персонажа: добавляет блок с криминальным статусом внизу текста. 
- Информация показывается только при наличии доступа к SecHUD (очки охраны, киберглаза  СБ и т.д.) и только для активного статуса, отличного от `None`.

#criminal-record-examine

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

<img width="1557" height="707" alt="256 symb" src="https://github.com/user-attachments/assets/90052e47-da97-4772-989f-5e5ce22cfe88" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
—

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- add: Добавлено отображение криминального статуса при осмотре персонажа, если у осматривающего есть очки охраны или аналогичный HUD.
