### PR TITLE
Увольнятор — табельное оружие главы персонала

### DIFF
--- a/Content.Goobstation.Server/Dismissinator/DismissinatorSystem.cs
+++ b/Content.Goobstation.Server/Dismissinator/DismissinatorSystem.cs
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+using Content.Goobstation.Shared.Dismissinator;
+using Content.Server.Access.Components;
+using Content.Server.Access.Systems;
+using Content.Server.Antag;
+using Content.Server.Explosion.EntitySystems;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Mind;
+using Content.Server.Roles;
+using Content.Server.Objectives;
+using Content.Server.Station.Systems;
+using Content.Shared.Access;
+using Content.Shared.Access.Components;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Database;
+using Content.Shared.GameTicking;
+using Content.Shared.Mind;
+using Content.Shared.Mindshield.Components;
+using Content.Shared.Paper;
+using Content.Shared.Popups;
+using Content.Shared.Projectiles;
+using Content.Shared.Roles;
+using Content.Shared.Weapons.Ranged.Events;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+
+namespace Content.Goobstation.Server.Dismissinator;
+
+/// <summary>
+///     Server half of the "увольнятор": stamps the loadout onto the fired bolt, and on impact strips the
+///     victim's ID card and drops a filled, stamped dismissal notice at their feet.
+/// </summary>
+public sealed class DismissinatorSystem : EntitySystem
+{
+    [Dependency] private readonly AccessSystem _access = default!;
+    [Dependency] private readonly IdCardSystem _idCard = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
+    [Dependency] private readonly AntagSelectionSystem _antag = default!;
+    [Dependency] private readonly ExplosionSystem _explosion = default!;
+    [Dependency] private readonly ISharedPlayerManager _player = default!;
+    [Dependency] private readonly MindSystem _mind = default!;
+    [Dependency] private readonly RoleSystem _roles = default!;
+    [Dependency] private readonly ObjectivesSystem _objectives = default!;
+    [Dependency] private readonly PaperSystem _paper = default!;
+    [Dependency] private readonly SharedDismissinatorSystem _dismissinator = default!;
+    [Dependency] private readonly SharedGameTicker _gameTicker = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly StationSystem _station = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DismissinatorComponent, AmmoShotEvent>(OnAmmoShot);
+        SubscribeLocalEvent<DismissalNoticeComponent, ProjectileHitEvent>(OnProjectileHit);
+    }
+
+    /// <summary>
+    ///     One sheet of paper is spent per bolt that actually leaves the barrel; the bolt carries a snapshot
+    ///     of the loadout with it.
+    /// </summary>
+    private void OnAmmoShot(Entity<DismissinatorComponent> ent, ref AmmoShotEvent args)
+    {
+        // The syndicate does not leave the recruiter holding evidence. Firing in the emagged mode cooks
+        // the gun off in their hands there and then, whatever the bolt goes on to hit or miss - tying it
+        // to the impact would let a reflected or stray bolt leave the gun intact. Yield comes from the
+        // gun's own Explosive component, so pulling that off the prototype disarms this entirely.
+        if (ent.Comp.Mode == DismissinatorMode.Objective)
+        {
+            // Held items are parented to whoever is holding them.
+            var holder = Transform(ent).ParentUid;
+
+            _explosion.TriggerExplosive(ent, user: holder.IsValid() ? holder : null);
+        }
+
+        foreach (var projectile in args.FiredProjectiles)
+        {
+            if (!_dismissinator.TryGetLoadout(ent, out var idCard, out _, out var stamp))
+                return;
+
+            // Consume the blank. A miss wastes it, same as any other form you fill in wrong.
+            if (!_itemSlots.TryEject(ent, ent.Comp.PaperSlotId, null, out var paper, doAfter: false))
+                return;
+
+            QueueDel(paper);
+
+            var notice = EnsureComp<DismissalNoticeComponent>(projectile);
+            notice.AuthorizedAccess = _dismissinator.GetAccessTags(idCard.Value);
+            notice.Mode = ent.Comp.Mode;
+            notice.Document = ent.Comp.Mode switch
+            {
+                DismissinatorMode.Expansion => ent.Comp.ExpansionDocument,
+                DismissinatorMode.Objective => ent.Comp.ObjectiveDocument,
+                _ => ent.Comp.DismissalDocument,
+            };
+            notice.TraitorRule = ent.Comp.TraitorRule;
+            notice.HitEffect = ent.Comp.HitEffect;
+            notice.StampState = stamp.Value.Comp.StampState;
+            notice.Stamp = new StampDisplayInfo
+            {
+                StampedName = stamp.Value.Comp.StampedName,
+                StampedColor = stamp.Value.Comp.StampedColor,
+                StampLargeIcon = stamp.Value.Comp.StampLargeIcon,
+            };
+            notice.AuthorName = idCard.Value.Comp.FullName ?? Loc.GetString("dismissinator-unknown");
+            notice.AuthorJob = idCard.Value.Comp.LocalizedJobTitle ?? Loc.GetString("dismissinator-unknown");
+        }
+    }
+
+    private void OnProjectileHit(Entity<DismissalNoticeComponent> ent, ref ProjectileHitEvent args)
+    {
+        var target = args.Target;
+
+        if (ent.Comp.HitEffect is { } effect)
+            Spawn(effect, Transform(target).Coordinates);
+
+        if (ent.Comp.Mode == DismissinatorMode.Objective)
+        {
+            ServeDirective(ent, target, args.Shooter);
+            return;
+        }
+
+        if (!_idCard.TryFindIdCard(target, out var idCard))
+            return;
+
+        // An agent ID forges its credentials rather than being issued them, so there is nothing on file
+        // to act on. Everything below runs off what the forgery claims instead, and the paperwork reads
+        // like any other notice: neither side is told the card was fake.
+        var forged = HasComp<AgentIDCardComponent>(idCard);
+
+        var claimed = forged
+            ? GetForgedAccess(idCard)
+            : (_access.TryGetTags(idCard) ?? Array.Empty<ProtoId<AccessLevelPrototype>>()).ToList();
+
+        var authorized = new HashSet<ProtoId<AccessLevelPrototype>>(ent.Comp.AuthorizedAccess);
+
+        // What the notice reports: clearance taken away, or clearance signed over.
+        List<ProtoId<AccessLevelPrototype>> listed;
+
+        if (ent.Comp.Mode == DismissinatorMode.Expansion)
+        {
+            // You can only sign over clearance you hold yourself, so this needs no rank check.
+            listed = authorized.Except(claimed).OrderBy(tag => tag.Id).ToList();
+
+            if (!forged)
+                _access.TrySetTags(idCard, claimed.Concat(listed));
+        }
+        else
+        {
+            // You cannot dismiss someone cleared for doors you are not, the same rule the ID console
+            // enforces on what a privileged card may give or take. So the HoP cannot fire another head,
+            // and the captain cannot fire the NT representative.
+            if (!authorized.IsSupersetOf(claimed))
+            {
+                if (args.Shooter is { } shooter)
+                    _popup.PopupEntity(Loc.GetString("dismissinator-outranked"), shooter, shooter, PopupType.MediumCaution);
+
+                _adminLogger.Add(LogType.Action,
+                    LogImpact.Low,
+                    $"{ToPrettyString(args.Shooter):player} failed to dismiss {ToPrettyString(target):entity}: {ToPrettyString(idCard):entity} holds [{string.Join(", ", claimed.Except(authorized))}], which the authorizing card cannot revoke");
+
+                return;
+            }
+
+            listed = claimed;
+
+            if (!forged)
+                _access.TrySetTags(idCard, Array.Empty<ProtoId<AccessLevelPrototype>>());
+        }
+
+        SpawnNotice(ent, target, idCard, listed);
+
+        var expansion = ent.Comp.Mode == DismissinatorMode.Expansion;
+
+        _popup.PopupEntity(Loc.GetString(expansion ? "dismissinator-expansion-popup" : "dismissinator-hit-popup"),
+            target,
+            target,
+            PopupType.LargeCaution);
+
+        // Admins still see the truth, even though nobody in-game does.
+        var action = expansion ? "expanded access for" : "dismissed";
+
+        if (forged)
+        {
+            _adminLogger.Add(LogType.Action,
+                LogImpact.High,
+                $"{ToPrettyString(args.Shooter):player} {action} {ToPrettyString(target):entity}, but {ToPrettyString(idCard):entity} is an agent ID: nothing was changed and the notice lists [{string.Join(", ", listed)}] instead");
+        }
+        else
+        {
+            _adminLogger.Add(LogType.Action,
+                LogImpact.High,
+                $"{ToPrettyString(args.Shooter):player} {action} {ToPrettyString(target):entity}: [{string.Join(", ", listed)}] on {ToPrettyString(idCard):entity}");
+        }
+    }
+
+    /// <summary>
+    ///     The access a genuine card bearing the same job icon would carry. Printed on the notice in place
+    ///     of an agent ID's real tags, so the document itself gives nothing away.
+    /// </summary>
+    private List<ProtoId<AccessLevelPrototype>> GetForgedAccess(Entity<IdCardComponent> idCard)
+    {
+        // Several jobs can share an icon; ordering by id keeps the same one picked every time.
+        foreach (var job in _prototype.EnumeratePrototypes<JobPrototype>().OrderBy(job => job.ID))
+        {
+            if (job.Icon != idCard.Comp.JobIcon)
+                continue;
+
+            var tags = new HashSet<ProtoId<AccessLevelPrototype>>(job.Access);
+
+            foreach (var group in job.AccessGroups)
+            {
+                tags.UnionWith(_prototype.Index(group).Tags);
+            }
+
+            return tags.OrderBy(tag => tag.Id).ToList();
+        }
+
+        // No job claims that icon, so fall back to whatever the card says it holds.
+        return (_access.TryGetTags(idCard) ?? Array.Empty<ProtoId<AccessLevelPrototype>>()).ToList();
+    }
+
+    private void SpawnNotice(Entity<DismissalNoticeComponent> ent,
+        EntityUid target,
+        Entity<IdCardComponent> idCard,
+        List<ProtoId<AccessLevelPrototype>> listed)
+    {
+        var text = ent.Comp.Mode == DismissinatorMode.Expansion
+            ? "dismissinator-expansion-document-text"
+            : "dismissinator-document-text";
+
+        SpawnPaper(ent,
+            target,
+            text,
+            ("name", idCard.Comp.FullName ?? Name(target)),
+            ("job", idCard.Comp.LocalizedJobTitle ?? Loc.GetString("dismissinator-unknown")),
+            ("access", FormatAccess(listed)),
+            ("authorName", ent.Comp.AuthorName),
+            ("authorJob", ent.Comp.AuthorJob));
+    }
+
+    /// <summary>
+    ///     Emag-only mode: recruits the target into the syndicate outright and serves them the standing
+    ///     orders that come with it.
+    /// </summary>
+    private void ServeDirective(Entity<DismissalNoticeComponent> ent, EntityUid target, EntityUid? shooter)
+    {
+        // A mindshield blocks the recruitment outright, and says nothing about why.
+        if (HasComp<MindShieldComponent>(target))
+        {
+            _adminLogger.Add(LogType.Action,
+                LogImpact.Medium,
+                $"{ToPrettyString(shooter):player} failed to recruit {ToPrettyString(target):entity}: mindshielded");
+
+            return;
+        }
+
+        if (!_mind.TryGetMind(target, out var mindId, out var mind))
+            return;
+
+        // Already working for them; there is nothing left to hand over.
+        if (_roles.MindHasRole<TraitorRoleComponent>(mindId))
+            return;
+
+        if (mind.UserId is not { } userId || !_player.TryGetSessionById(userId, out var session))
+            return;
+
+        // The rule hands out the uplink, codewords and objectives; we only report what it settled on.
+        var before = new HashSet<EntityUid>(mind.Objectives);
+
+        _antag.ForceMakeAntag<TraitorRuleComponent>(session, ent.Comp.TraitorRule);
+
+        var objectives = mind.Objectives.Where(objective => !before.Contains(objective)).ToList();
+
+        SpawnPaper(ent,
+            target,
+            "dismissinator-objective-document-text",
+            ("name", Name(target)),
+            ("objectives", FormatObjectives(objectives, mindId, mind)));
+
+        _popup.PopupEntity(Loc.GetString("dismissinator-objective-popup"), target, target, PopupType.LargeCaution);
+
+        _adminLogger.Add(LogType.Action,
+            LogImpact.Extreme,
+            $"{ToPrettyString(shooter):player} recruited {ToPrettyString(target):entity} into {ent.Comp.TraitorRule} with objectives [{string.Join(", ", objectives.Select(o => Name(o)))}]");
+    }
+
+    private string FormatObjectives(List<EntityUid> objectives, EntityUid mindId, MindComponent mind)
+    {
+        if (objectives.Count == 0)
+            return Loc.GetString("dismissinator-objectives-none");
+
+        var lines = new List<string>();
+
+        foreach (var objective in objectives)
+        {
+            var info = _objectives.GetInfo(objective, mindId, mind);
+
+            lines.Add($"⠀[bold]{info?.Title ?? Name(objective)}[/bold]");
+
+            if (!string.IsNullOrWhiteSpace(info?.Description))
+                lines.Add(info.Value.Description);
+        }
+
+        return string.Join("\n", lines);
+    }
+
+    /// <summary>
+    ///     Drops a stamped, filled-in form at the target's feet. Station and date are filled the same way
+    ///     the document printer does it.
+    /// </summary>
+    private void SpawnPaper(Entity<DismissalNoticeComponent> ent,
+        EntityUid target,
+        string text,
+        params (string, object)[] args)
+    {
+        var document = Spawn(ent.Comp.Document, Transform(target).Coordinates);
+
+        if (!TryComp<PaperComponent>(document, out var paper))
+            return;
+
+        var station = _station.GetOwningStation(target);
+
+        var full = new List<(string, object)>
+        {
+            ("station", station != null ? Name(station.Value) : Loc.GetString("dismissinator-unknown")),
+            ("date", GetStationTime()),
+        };
+        full.AddRange(args);
+
+        _paper.SetContent((document, paper), Loc.GetString(text, full.ToArray()));
+
+        _paper.TryStamp((document, paper), ent.Comp.Stamp, ent.Comp.StampState);
+    }
+
+    private string FormatAccess(List<ProtoId<AccessLevelPrototype>> listed)
+    {
+        return listed.Count == 0
+            ? Loc.GetString("dismissinator-access-none")
+            : string.Join(", ", listed.Select(x => x.Id));
+    }
+
+    /// <summary>
+    ///     Same shift-time + fake-date format the document printer uses.
+    /// </summary>
+    private string GetStationTime()
+    {
+        var time = _gameTicker.RoundDuration().ToString("hh\\:mm\\:ss");
+        return time + " " + DateTime.Now.AddYears(1000).ToShortDateString();
+    }
+}

--- a/Content.Goobstation.Shared/Dismissinator/DismissalNoticeComponent.cs
+++ b/Content.Goobstation.Shared/Dismissinator/DismissalNoticeComponent.cs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Access;
+using Content.Shared.Paper;
+using Robust.Shared.Prototypes;
+
+namespace Content.Goobstation.Shared.Dismissinator;
+
+/// <summary>
+///     Attached to a projectile fired from a <see cref="DismissinatorComponent"/>.
+///     Carries everything the projectile needs on impact, so the gun itself may be dropped,
+///     emptied or destroyed while the bolt is still in flight.
+/// </summary>
+[RegisterComponent]
+public sealed partial class DismissalNoticeComponent : Component
+{
+    /// <summary>
+    ///     Access tags the authorizing ID card held at the moment of the shot. The target can only be
+    ///     dismissed if everything on their card falls within this set.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<AccessLevelPrototype>> AuthorizedAccess = new();
+
+    [DataField]
+    public StampDisplayInfo Stamp;
+
+    [DataField]
+    public string StampState = "paper_stamp-generic";
+
+    /// <summary>
+    ///     Which paperwork this bolt is carrying, fixed at the moment of the shot.
+    /// </summary>
+    [DataField]
+    public DismissinatorMode Mode = DismissinatorMode.Dismissal;
+
+    [DataField]
+    public EntProtoId Document = "PaperDismissalNotice";
+
+    /// <summary>
+    ///     Game rule the target is recruited into by <see cref="DismissinatorMode.Objective"/>.
+    /// </summary>
+    [DataField]
+    public EntProtoId TraitorRule = "Traitor";
+
+    [DataField]
+    public EntProtoId? HitEffect = "EffectEmpPulse";
+
+    /// <summary>
+    ///     Full name / job title taken from the authorizing ID card, used to fill in the notice.
+    /// </summary>
+    [DataField]
+    public string AuthorName = string.Empty;
+
+    [DataField]
+    public string AuthorJob = string.Empty;
+}

--- a/Content.Goobstation.Shared/Dismissinator/DismissinatorComponent.cs
+++ b/Content.Goobstation.Shared/Dismissinator/DismissinatorComponent.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Access;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Goobstation.Shared.Dismissinator;
+
+/// <summary>
+///     "Увольнятор" — HoP sidearm. Requires an authorized ID card, a sheet of paper and a rubber stamp
+///     inserted into it. On hit it strips the victim's ID card and spits out a filled, stamped dismissal notice.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class DismissinatorComponent : Component
+{
+    /// <summary>
+    ///     ItemSlot ids, see the ItemSlots component on the prototype.
+    /// </summary>
+    [DataField]
+    public string IdSlotId = "dismissinator-id";
+
+    [DataField]
+    public string PaperSlotId = "dismissinator-paper";
+
+    [DataField]
+    public string StampSlotId = "dismissinator-stamp";
+
+    /// <summary>
+    ///     The inserted ID card must hold this access level, otherwise the gun refuses to fire.
+    /// </summary>
+    [DataField]
+    public ProtoId<AccessLevelPrototype> RequiredAccess = "HeadOfPersonnel";
+
+    /// <summary>
+    ///     Which paperwork the next shot serves. Toggled in hand or through the alt-click verb.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public DismissinatorMode Mode = DismissinatorMode.Dismissal;
+
+    /// <summary>
+    ///     Document spawned at the target on hit, per mode.
+    /// </summary>
+    [DataField]
+    public EntProtoId DismissalDocument = "PaperDismissalNotice";
+
+    [DataField]
+    public EntProtoId ExpansionDocument = "PaperAccessExpansionNotice";
+
+    [DataField]
+    public EntProtoId ObjectiveDocument = "PaperCovertDirective";
+
+    /// <summary>
+    ///     Game rule the emagged mode recruits the target into.
+    /// </summary>
+    [DataField]
+    public EntProtoId TraitorRule = "Traitor";
+
+    /// <summary>
+    ///     Visual effect played on the victim on hit.
+    /// </summary>
+    [DataField]
+    public EntProtoId? HitEffect = "EffectEmpPulse";
+}

--- a/Content.Goobstation.Shared/Dismissinator/DismissinatorMode.cs
+++ b/Content.Goobstation.Shared/Dismissinator/DismissinatorMode.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.Serialization;
+
+namespace Content.Goobstation.Shared.Dismissinator;
+
+/// <summary>
+///     Which way the paperwork runs.
+/// </summary>
+[Serializable, NetSerializable]
+public enum DismissinatorMode : byte
+{
+    /// <summary>
+    ///     Strips the target's card and serves a dismissal notice.
+    /// </summary>
+    Dismissal,
+
+    /// <summary>
+    ///     Signs over the authorizing card's own clearance and serves an access expansion notice.
+    /// </summary>
+    Expansion,
+
+    /// <summary>
+    ///     Emag-only. Saddles the target's mind with a syndicate objective and serves it as a directive.
+    /// </summary>
+    Objective,
+}

--- a/Content.Goobstation.Shared/Dismissinator/SharedDismissinatorSystem.cs
+++ b/Content.Goobstation.Shared/Dismissinator/SharedDismissinatorSystem.cs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Content.Shared.Access;
+using Content.Shared.Access.Components;
+using Content.Shared.Access.Systems;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Emag.Systems;
+using Content.Shared.Examine;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Paper;
+using Content.Shared.Popups;
+using Content.Shared.Verbs;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Prototypes;
+
+namespace Content.Goobstation.Shared.Dismissinator;
+
+/// <summary>
+///     Gates firing of the "увольнятор" on it being loaded with an authorized ID card, paper and a stamp.
+///     Shared so that the client predicts the refusal instead of eating a rubberband.
+/// </summary>
+public sealed class SharedDismissinatorSystem : EntitySystem
+{
+    [Dependency] private readonly AccessReaderSystem _accessReader = default!;
+    [Dependency] private readonly EmagSystem _emag = default!;
+    [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DismissinatorComponent, AttemptShootEvent>(OnAttemptShoot);
+        SubscribeLocalEvent<DismissinatorComponent, UseInHandEvent>(OnUseInHand);
+        SubscribeLocalEvent<DismissinatorComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+        SubscribeLocalEvent<DismissinatorComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<DismissinatorComponent, GotEmaggedEvent>(OnEmagged);
+    }
+
+    /// <summary>
+    ///     Unlocks the third mode. Nothing else about the gun changes.
+    /// </summary>
+    private void OnEmagged(Entity<DismissinatorComponent> ent, ref GotEmaggedEvent args)
+    {
+        if (!_emag.CompareFlag(args.Type, EmagType.Interaction) || _emag.CheckFlag(ent, EmagType.Interaction))
+            return;
+
+        args.Handled = true;
+    }
+
+    private void OnUseInHand(Entity<DismissinatorComponent> ent, ref UseInHandEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        ToggleMode(ent, args.User);
+        args.Handled = true;
+    }
+
+    private void OnGetVerbs(Entity<DismissinatorComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        var user = args.User;
+
+        args.Verbs.Add(new AlternativeVerb
+        {
+            Text = Loc.GetString("dismissinator-verb-toggle-mode"),
+            Act = () => ToggleMode(ent, user),
+        });
+    }
+
+    private void OnExamined(Entity<DismissinatorComponent> ent, ref ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("dismissinator-examine-mode", ("mode", GetModeName(ent.Comp.Mode))));
+    }
+
+    public void ToggleMode(Entity<DismissinatorComponent> ent, EntityUid user)
+    {
+        ent.Comp.Mode = ent.Comp.Mode switch
+        {
+            DismissinatorMode.Dismissal => DismissinatorMode.Expansion,
+            DismissinatorMode.Expansion when _emag.CheckFlag(ent, EmagType.Interaction) => DismissinatorMode.Objective,
+            _ => DismissinatorMode.Dismissal,
+        };
+
+        Dirty(ent);
+
+        _popup.PopupClient(Loc.GetString("dismissinator-mode-switched", ("mode", GetModeName(ent.Comp.Mode))), ent, user);
+    }
+
+    public string GetModeName(DismissinatorMode mode)
+    {
+        return Loc.GetString(mode switch
+        {
+            DismissinatorMode.Expansion => "dismissinator-mode-expansion",
+            DismissinatorMode.Objective => "dismissinator-mode-objective",
+            _ => "dismissinator-mode-dismissal",
+        });
+    }
+
+    private void OnAttemptShoot(Entity<DismissinatorComponent> ent, ref AttemptShootEvent args)
+    {
+        string? reason = null;
+
+        if (GetIdCard(ent) is not { } idCard)
+            reason = "dismissinator-no-id";
+        else if (!IsAuthorized(ent, idCard))
+            reason = "dismissinator-no-authority";
+        else if (GetPaper(ent) == null)
+            reason = "dismissinator-no-paper";
+        else if (GetStamp(ent) == null)
+            reason = "dismissinator-no-stamp";
+
+        if (reason == null)
+            return;
+
+        args.Cancelled = true;
+        args.Message = Loc.GetString(reason);
+    }
+
+    /// <summary>
+    ///     The ID card inserted into the authorization slot, if any.
+    /// </summary>
+    public Entity<IdCardComponent>? GetIdCard(Entity<DismissinatorComponent> ent)
+    {
+        if (_itemSlots.GetItemOrNull(ent, ent.Comp.IdSlotId) is not { } item
+            || !TryComp<IdCardComponent>(item, out var idCard))
+        {
+            return null;
+        }
+
+        return (item, idCard);
+    }
+
+    public Entity<PaperComponent>? GetPaper(Entity<DismissinatorComponent> ent)
+    {
+        if (_itemSlots.GetItemOrNull(ent, ent.Comp.PaperSlotId) is not { } item
+            || !TryComp<PaperComponent>(item, out var paper))
+        {
+            return null;
+        }
+
+        return (item, paper);
+    }
+
+    public Entity<StampComponent>? GetStamp(Entity<DismissinatorComponent> ent)
+    {
+        if (_itemSlots.GetItemOrNull(ent, ent.Comp.StampSlotId) is not { } item
+            || !TryComp<StampComponent>(item, out var stamp))
+        {
+            return null;
+        }
+
+        return (item, stamp);
+    }
+
+    /// <summary>
+    ///     True if the inserted card carries the access level that lets it hand out and revoke access.
+    /// </summary>
+    public bool IsAuthorized(Entity<DismissinatorComponent> ent, EntityUid idCard)
+    {
+        return GetAccessTags(idCard).Contains(ent.Comp.RequiredAccess);
+    }
+
+    public List<ProtoId<AccessLevelPrototype>> GetAccessTags(EntityUid idCard)
+    {
+        return _accessReader.FindAccessTags(idCard).ToList();
+    }
+
+    /// <summary>
+    ///     Everything loaded and authorized, ready to fire.
+    /// </summary>
+    public bool TryGetLoadout(Entity<DismissinatorComponent> ent,
+        [NotNullWhen(true)] out Entity<IdCardComponent>? idCard,
+        [NotNullWhen(true)] out Entity<PaperComponent>? paper,
+        [NotNullWhen(true)] out Entity<StampComponent>? stamp)
+    {
+        paper = null;
+        stamp = null;
+
+        idCard = GetIdCard(ent);
+        if (idCard == null || !IsAuthorized(ent, idCard.Value))
+        {
+            idCard = null;
+            return false;
+        }
+
+        paper = GetPaper(ent);
+        stamp = GetStamp(ent);
+
+        if (paper != null && stamp != null)
+            return true;
+
+        idCard = null;
+        paper = null;
+        stamp = null;
+        return false;
+    }
+}

--- a/Resources/Locale/en-US/_Goobstation/dismissinator/dismissinator.ftl
+++ b/Resources/Locale/en-US/_Goobstation/dismissinator/dismissinator.ftl
@@ -1,0 +1,77 @@
+dismissinator-slot-id = ID card
+dismissinator-slot-paper = blank
+dismissinator-slot-stamp = rubber stamp
+
+dismissinator-no-id = No ID card inserted!
+dismissinator-no-authority = The inserted ID card is not authorized to alter access!
+dismissinator-no-paper = No blank inserted!
+dismissinator-no-stamp = No rubber stamp inserted!
+
+dismissinator-hit-popup = You have been dismissed!
+dismissinator-outranked = Denied: the target is cleared for access your card does not carry!
+dismissinator-unknown = UNKNOWN
+dismissinator-access-none = none
+
+dismissinator-document-text =
+    ⠀[head=3]Nanotrasen[/head]
+    ⠀[head=3]NOTICE OF DISMISSAL[/head]
+    =============================================
+    Station: { $station }
+    Shift time and date: { $date }
+
+    Employee: { $name }
+    Position: { $job }
+
+    By the present notice the above employee is relieved of their duties.
+    All station access has been revoked.
+
+    Revoked access: { $access }
+
+    Issued by: { $authorName }
+    Position: { $authorJob }
+    =============================================
+
+dismissinator-verb-toggle-mode = Switch mode
+dismissinator-mode-dismissal = dismissal
+dismissinator-mode-expansion = access expansion
+dismissinator-mode-switched = Mode: { $mode }.
+dismissinator-examine-mode = Set to [color=#6ec0ea]{ $mode }[/color].
+dismissinator-expansion-popup = Your clearance has been expanded!
+
+dismissinator-expansion-document-text =
+    ⠀[head=3]Nanotrasen[/head]
+    ⠀[head=3]NOTICE OF CLEARANCE EXPANSION[/head]
+    =============================================
+    Station: { $station }
+    Shift time and date: { $date }
+
+    Employee: { $name }
+    Position: { $job }
+
+    By the present notice the above employee is granted additional station clearance.
+
+    Granted access: { $access }
+
+    Issued by: { $authorName }
+    Position: { $authorJob }
+    =============================================
+
+dismissinator-mode-objective = recruitment
+dismissinator-objective-popup = You have been given a new assignment!
+
+dismissinator-objectives-none = none on file
+dismissinator-objective-document-text =
+    ⠀[head=3]Nanotrasen[/head]
+    ⠀[head=3]ASSIGNMENT ORDER[/head]
+    =============================================
+    Station: { $station }
+    Shift time and date: { $date }
+
+    Employee: { $name }
+
+    The above employee is hereby assigned the following, effective immediately:
+
+    { $objectives }
+
+    =============================================
+    ⠀[italic]This order supersedes all standing instructions.[/italic]

--- a/Resources/Locale/ru-RU/_Goobstation/dismissinator/dismissinator.ftl
+++ b/Resources/Locale/ru-RU/_Goobstation/dismissinator/dismissinator.ftl
@@ -1,0 +1,89 @@
+ent-WeaponDismissinator = увольнятор
+    .desc = Табельное оружие главы персонала. Зарядите его авторизованной айди-картой, бланком и печатью — и вручайте документы дистанционно.
+ent-BulletDismissinator = увольнительный заряд
+ent-PaperDismissalNotice = приказ об увольнении
+    .desc = Бланк приказа об увольнении НТ. Заполняется в момент вручения.
+
+dismissinator-slot-id = Айди-карта
+dismissinator-slot-paper = Бланк
+dismissinator-slot-stamp = Печать
+
+dismissinator-no-id = Не вставлена айди-карта!
+dismissinator-no-authority = У вставленной айди-карты нет полномочий менять доступы!
+dismissinator-no-paper = Не вставлен бланк!
+dismissinator-no-stamp = Не вставлена печать!
+
+dismissinator-hit-popup = Вы уволены!
+dismissinator-outranked = Отказано: у цели есть допуски, которых нет на вашей карте!
+dismissinator-unknown = НЕИЗВЕСТНО
+dismissinator-access-none = отсутствуют
+
+dismissinator-document-text =
+    ⠀[head=3]NanoTrasen[/head]
+    ⠀[head=3]ПРИКАЗ ОБ УВОЛЬНЕНИИ[/head]
+    =============================================
+    Станция: { $station }
+    Время от начала смены и дата: { $date }
+
+    Сотрудник: { $name }
+    Должность: { $job }
+
+    Настоящим приказом указанный сотрудник освобождается от занимаемой должности.
+    Все станционные доступы аннулированы.
+
+    Аннулированные доступы: { $access }
+
+    Приказ издал: { $authorName }
+    Должность: { $authorJob }
+    =============================================
+
+ent-PaperAccessExpansionNotice = приказ о расширении доступа
+    .desc = Бланк приказа НТ о расширении доступа. Заполняется в момент вручения.
+
+dismissinator-verb-toggle-mode = Переключить режим
+dismissinator-mode-dismissal = увольнение
+dismissinator-mode-expansion = расширение доступа
+dismissinator-mode-switched = Режим: { $mode }.
+dismissinator-examine-mode = Выставлен режим: [color=#6ec0ea]{ $mode }[/color].
+dismissinator-expansion-popup = Ваши полномочия расширены!
+
+dismissinator-expansion-document-text =
+    ⠀[head=3]NanoTrasen[/head]
+    ⠀[head=3]ПРИКАЗ О РАСШИРЕНИИ ДОСТУПА[/head]
+    =============================================
+    Станция: { $station }
+    Время от начала смены и дата: { $date }
+
+    Сотрудник: { $name }
+    Должность: { $job }
+
+    Настоящим приказом указанному сотруднику предоставляется дополнительный станционный доступ.
+
+    Выданные доступы: { $access }
+
+    Приказ издал: { $authorName }
+    Должность: { $authorJob }
+    =============================================
+
+ent-PaperCovertDirective = служебное предписание
+    .desc = Типовой бланк служебного задания НТ. Заполняется в момент вручения.
+
+dismissinator-mode-objective = вербовка
+dismissinator-objective-popup = Вам поручено новое задание!
+
+dismissinator-objectives-none = не установлены
+dismissinator-objective-document-text =
+    ⠀[head=3]NanoTrasen[/head]
+    ⠀[head=3]СЛУЖЕБНОЕ ПРЕДПИСАНИЕ[/head]
+    =============================================
+    Станция: { $station }
+    Время от начала смены и дата: { $date }
+
+    Сотрудник: { $name }
+
+    Настоящим предписанием указанному сотруднику поручается следующее, к исполнению немедленно:
+
+    { $objectives }
+
+    =============================================
+    ⠀[italic]Настоящее предписание имеет приоритет над всеми прочими указаниями.[/italic]

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/dismissinator.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/dismissinator.yml
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: entity
+  name: dismissinator
+  parent: [WeaponDisablerPractice, BaseCommandContraband]
+  id: WeaponDismissinator
+  description: A Head of Personnel's sidearm. Load it with an authorized ID card, a blank and a rubber stamp, then serve the paperwork at range.
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Battery/disabler.rsi
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-unshaded-0
+      map: ["enum.GunVisualLayers.MagUnshaded"]
+      shader: unshaded
+  - type: Clothing
+    sprite: Objects/Weapons/Guns/Battery/disabler.rsi
+    quickEquip: false
+    slots:
+    - suitStorage
+    - Belt
+  - type: Gun
+    fireRate: 1
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
+  - type: BatteryAmmoProvider
+    proto: BulletDismissinator
+    fireCost: 100
+  - type: Dismissinator
+  - type: ContainerContainer
+    containers:
+      dismissinator-id: !type:ContainerSlot
+      dismissinator-paper: !type:ContainerSlot
+      dismissinator-stamp: !type:ContainerSlot
+  - type: ItemSlots
+    slots:
+      dismissinator-id:
+        name: dismissinator-slot-id
+        whitelist:
+          components:
+          - IdCard
+      dismissinator-paper:
+        name: dismissinator-slot-paper
+        whitelist:
+          components:
+          - Paper
+      dismissinator-stamp:
+        name: dismissinator-slot-stamp
+        whitelist:
+          components:
+          - Stamp
+  - type: Tag
+    tags:
+    - Sidearm
+  # Set off whenever the gun is fired in the emagged recruitment mode, see DismissinatorSystem.OnAmmoShot.
+  - type: Explosive
+    explosionType: Default
+    maxIntensity: 8
+    intensitySlope: 5
+    totalIntensity: 20
+    canCreateVacuum: false
+
+- type: entity
+  name: dismissal bolt
+  id: BulletDismissinator
+  parent: BaseBullet
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Reflective
+    reflective:
+    - Energy
+  - type: FlyBySound
+    sound:
+      collection: EnergyMiss
+      params:
+        volume: 5
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles_tg.rsi
+    layers:
+    - state: omnilaser
+      shader: unshaded
+  - type: Physics
+  - type: Fixtures
+    fixtures:
+      projectile:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.15,-0.3,0.15,0.3"
+        hard: false
+        mask:
+        - Opaque
+      fly-by:
+        shape: !type:PhysShapeCircle
+          radius: 1.5
+        layer:
+        - Impassable
+        - MidImpassable
+        - HighImpassable
+        - LowImpassable
+        hard: False
+  - type: Ammo
+  - type: Projectile
+    impactEffect: BulletImpactEffectDisabler
+    damage:
+      types:
+        Heat: 0
+    soundHit:
+      collection: WeakHit
+    forceSound: true
+
+- type: entity
+  parent: Paper
+  id: PaperDismissalNotice
+  name: dismissal notice
+  description: A pre-filled Nanotrasen personnel dismissal notice. Content is written at the moment it is served.
+  components:
+  - type: Paper
+
+- type: entity
+  parent: Paper
+  id: PaperAccessExpansionNotice
+  name: access expansion notice
+  description: A pre-filled Nanotrasen clearance expansion notice. Content is written at the moment it is served.
+  components:
+  - type: Paper
+
+- type: entity
+  parent: Paper
+  id: PaperCovertDirective
+  name: sealed directive
+  description: A standard Nanotrasen assignment form. Content is written at the moment it is served.
+  components:
+  - type: Paper


### PR DESCRIPTION
## Описание PR

Добавляет **увольнятор** — табельное оружие главы персонала для дистанционного оформления кадровых приказов. Урона не наносит вообще.

Чтобы выстрелить, в оружие нужно вставить три предмета: айди-карту с доступом главы персонала, чистый бланк и печать. Бланк расходуется на каждый выстрел, промах в том числе.

Режимы переключаются нажатием в руке или альт-кликом:

| Режим | Что делает с картой цели | Какой бланк выдаёт |
|---|---|---|
| Увольнение | обнуляет все допуски | приказ об увольнении |
| Расширение | добавляет допуски карты-авторизатора | приказ о расширении доступа |
| Вербовка (только после емага) | не трогает | служебное предписание |

Приказ падает под ноги цели уже заполненным — станция, время смены, ФИО и должность с карты, список затронутых допусков, кто издал — и с проставленной печатью из самого оружия.

## Почему / Баланс

Ограничения, которые не дают этому превратиться в кнопку тотального контроля:

- **Нельзя уволить того, кто выше по допускам.** Все допуски цели должны укладываться в допуски вставленной карты. Это то же правило, которое `IdCardConsoleSystem` применяет к привилегированной карте в консоли ГП. На практике: ГП не уволит другого главу, капитан не уволит представителя ЦК, а вот пассажира или сервисный отдел уволит любой обладатель карты ГП.
- **Расход бланков.** Один выстрел — один бланк. Работать очередями не выйдет, перезарядка ручная.
- **Карты агента не поддаются.** Приказ печатается с допусками, которые были бы у настоящей карты с такой же иконкой должности, но сама карта не меняется и никакого сообщения о подделке не выводится. Оружие намеренно не работает как детектор агентских карт.
- **Емагнутый режим одноразовый.** Вербовка делает цель полноценным предателем — аплинк, кодовые слова, цели, — но выстрел в этом режиме детонирует само оружие в руках стрелка. На носителях щита разума не срабатывает.

**Выдача пока не решена.** Оружие не прописано ни в шкафчик ГП, ни в латэ, ни в вендинг — сейчас получить его можно только админским спавном. Сознательно оставлено на усмотрение ревьюеров: скажите, куда добавить, и допишу в этом же PR.

## Технические детали

Код лежит в `Content.Goobstation.Shared/Dismissinator/` и `Content.Goobstation.Server/Dismissinator/`, новых ассетов нет — спрайты переиспользованы от станнера.

- `SharedDismissinatorSystem` ловит `AttemptShootEvent` и блокирует выстрел, если не хватает карты, полномочий, бланка или печати. Там же переключение режимов и обработка `GotEmaggedEvent`. Вынесено в shared, чтобы клиент предсказывал отказ, а не ловил руббербенд.
- `DismissinatorSystem` на `AmmoShotEvent` списывает бланк и вешает на снаряд `DismissalNoticeComponent` со снимком зарядки — допуски карты, печать, ФИО и должность автора, режим. После этого оружие можно выбросить или уничтожить, снаряд доработает сам.
- На `ProjectileHitEvent` карта цели ищется через `SharedIdCardSystem.TryFindIdCard` (он же достаёт карту из КПК), допуски меняются через `AccessSystem.TrySetTags`, бланк заполняется `PaperSystem.SetContent` и штампуется `PaperSystem.TryStamp`.
- Вербовка идёт через `AntagSelectionSystem.ForceMakeAntag<TraitorRuleComponent>` — тем же путём, что и админская кнопка «Сделать предателем». Правило само выдаёт аплинк, кодовые слова и цели, система лишь снимает разницу `mind.Objectives` до и после и печатает её в предписание.
- Детонация — `ExplosionSystem.TriggerExplosive` на самом оружии в момент выстрела. Мощность целиком в компоненте `Explosive` в прототипе, кодом не задаётся.

Новые прототипы: `WeaponDismissinator`, `BulletDismissinator`, `PaperDismissalNotice`, `PaperAccessExpansionNotice`, `PaperCovertDirective`.

## Медиа

<!-- ВИДЕО ПЕРЕТАЩИТЬ СЮДА -->

## Требования

- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Критические изменения

Нет. Все файлы новые, существующие прототипы и системы не менялись.

:cl:
- add: Добавлен увольнятор — табельное оружие главы персонала. Заряжается айди-картой, бланком и печатью, дистанционно увольняет и расширяет доступы, оформляя приказ прямо на месте.
