### PR TITLE
offeritem update

### DIFF
--- a/Content.IntegrationTests/Tests/_Goobstation/OfferItem/OfferItemTest.cs
+++ b/Content.IntegrationTests/Tests/_Goobstation/OfferItem/OfferItemTest.cs
@@ -1,0 +1,265 @@
+using Content.Server._CorvaxGoob.OfferItem;
+using Content.Shared._CorvaxGoob.OfferItem;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Robust.Server.GameObjects;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
+
+namespace Content.IntegrationTests.Tests._Goobstation;
+
+[TestFixture]
+public sealed class OfferItemTest
+{
+    [Test]
+    public async Task AcceptOfferTransfersItemAndResetsBoth()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var handsSys = entMan.System<SharedHandsSystem>();
+        var offerSys = entMan.System<OfferItemSystem>();
+
+        var map = await pair.CreateTestMap();
+        await pair.RunTicksSync(5);
+
+        EntityUid a = default, b = default, item = default;
+        HandsComponent? aHands = default;
+        OfferItemComponent? compAAfter = null, compBAfter = null;
+
+        await server.WaitPost(() =>
+        {
+            a = entMan.SpawnEntity("MobHuman", map.GridCoords);
+            b = entMan.SpawnEntity("MobHuman", map.GridCoords);
+            item = entMan.SpawnEntity("Crowbar", map.GridCoords);
+
+            aHands = entMan.GetComponent<HandsComponent>(a);
+            Assert.That(handsSys.TryPickup(a, item, aHands.ActiveHandId!), Is.True);
+        });
+        await pair.RunTicksSync(2);
+
+        await server.WaitPost(() =>
+        {
+            var compA = entMan.GetComponent<OfferItemComponent>(a);
+            var compB = entMan.GetComponent<OfferItemComponent>(b);
+
+            offerSys.StartOffer(a, compA, item, aHands!.ActiveHandId!);
+            offerSys.LinkOffer(a, compA, b, compB);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(compA.IsInOfferMode, Is.False);
+                Assert.That(compA.Item, Is.EqualTo(item));
+                Assert.That(compA.Target, Is.EqualTo(b));
+                Assert.That(compB.IsInReceiveMode, Is.True);
+                Assert.That(compB.Target, Is.EqualTo(a));
+            });
+
+            offerSys.AcceptOffer(new Entity<OfferItemComponent>(b, compB));
+        });
+        await pair.RunTicksSync(5);
+
+        await server.WaitPost(() =>
+        {
+            Assert.That(handsSys.GetActiveItem(b), Is.EqualTo(item));
+
+            compAAfter = entMan.GetComponent<OfferItemComponent>(a);
+            compBAfter = entMan.GetComponent<OfferItemComponent>(b);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(compAAfter.IsInOfferMode, Is.False);
+                Assert.That(compAAfter.IsInReceiveMode, Is.False);
+                Assert.That(compAAfter.Hand, Is.Null);
+                Assert.That(compAAfter.Item, Is.Null);
+                Assert.That(compAAfter.Target, Is.Null);
+
+                Assert.That(compBAfter.IsInReceiveMode, Is.False);
+                Assert.That(compBAfter.Hand, Is.Null);
+                Assert.That(compBAfter.Item, Is.Null);
+                Assert.That(compBAfter.Target, Is.Null);
+            });
+
+            // PVS-сериализация очищенных компонентов не должна бросать исключений.
+            Assert.DoesNotThrow(() => entMan.GetComponentState(entMan.EventBus, compAAfter!, null, GameTick.Zero));
+            Assert.DoesNotThrow(() => entMan.GetComponentState(entMan.EventBus, compBAfter!, null, GameTick.Zero));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task MovingBeyondDistanceCancelsOffer()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var tSys = entMan.System<TransformSystem>();
+        var handsSys = entMan.System<SharedHandsSystem>();
+        var offerSys = entMan.System<OfferItemSystem>();
+
+        var map = await pair.CreateTestMap();
+        await pair.RunTicksSync(5);
+
+        EntityUid a = default, b = default, item = default;
+        HandsComponent? aHands = default;
+
+        await server.WaitPost(() =>
+        {
+            a = entMan.SpawnEntity("MobHuman", map.GridCoords);
+            b = entMan.SpawnEntity("MobHuman", map.GridCoords);
+            item = entMan.SpawnEntity("Crowbar", map.GridCoords);
+
+            aHands = entMan.GetComponent<HandsComponent>(a);
+            handsSys.TryPickup(a, item, aHands.ActiveHandId!);
+
+            var compA = entMan.GetComponent<OfferItemComponent>(a);
+            var compB = entMan.GetComponent<OfferItemComponent>(b);
+            offerSys.StartOffer(a, compA, item, aHands.ActiveHandId!);
+            offerSys.LinkOffer(a, compA, b, compB);
+        });
+        await pair.RunTicksSync(2);
+
+        await server.WaitPost(() =>
+        {
+            // Перемещаем A далеко за пределы стандартного MaxOfferDistance (2) от B.
+            var coords = tSys.GetMapCoordinates(b);
+            var farCoords = new MapCoordinates(coords.Position + new System.Numerics.Vector2(10, 0), coords.MapId);
+            tSys.SetCoordinates(a, tSys.ToCoordinates(farCoords));
+        });
+        await pair.RunTicksSync(2);
+
+        await server.WaitPost(() =>
+        {
+            var compA = entMan.GetComponent<OfferItemComponent>(a);
+            var compB = entMan.GetComponent<OfferItemComponent>(b);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(compA.IsInOfferMode, Is.False);
+                Assert.That(compA.IsInReceiveMode, Is.False);
+                Assert.That(compA.Item, Is.Null);
+                Assert.That(compA.Target, Is.Null);
+                Assert.That(compB.IsInReceiveMode, Is.False);
+                Assert.That(compB.Target, Is.Null);
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task QueueDeleteItemResetsOfferImmediately()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var handsSys = entMan.System<SharedHandsSystem>();
+        var offerSys = entMan.System<OfferItemSystem>();
+
+        var map = await pair.CreateTestMap();
+        await pair.RunTicksSync(5);
+
+        EntityUid a = default, b = default, item = default;
+        HandsComponent? aHands = default;
+
+        await server.WaitPost(() =>
+        {
+            a = entMan.SpawnEntity("MobHuman", map.GridCoords);
+            b = entMan.SpawnEntity("MobHuman", map.GridCoords);
+            item = entMan.SpawnEntity("Crowbar", map.GridCoords);
+
+            aHands = entMan.GetComponent<HandsComponent>(a);
+            handsSys.TryPickup(a, item, aHands.ActiveHandId!);
+
+            var compA = entMan.GetComponent<OfferItemComponent>(a);
+            var compB = entMan.GetComponent<OfferItemComponent>(b);
+            offerSys.StartOffer(a, compA, item, aHands.ActiveHandId!);
+            offerSys.LinkOffer(a, compA, b, compB);
+
+            entMan.QueueDeleteEntity(item);
+        });
+
+        // Без долгого поллинга: сброс должен произойти уже к моменту завершения удаления.
+        await pair.RunTicksSync(5);
+
+        await server.WaitPost(() =>
+        {
+            var compA = entMan.GetComponent<OfferItemComponent>(a);
+            var compB = entMan.GetComponent<OfferItemComponent>(b);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(compA.IsInOfferMode, Is.False);
+                Assert.That(compA.Item, Is.Null);
+                Assert.That(compA.Target, Is.Null);
+                Assert.That(compB.IsInReceiveMode, Is.False);
+                Assert.That(compB.Target, Is.Null);
+            });
+
+            Assert.DoesNotThrow(() => entMan.GetComponentState(entMan.EventBus, compA, null, GameTick.Zero));
+            Assert.DoesNotThrow(() => entMan.GetComponentState(entMan.EventBus, compB, null, GameTick.Zero));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task DeletingOfferingSideResetsPartner()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var handsSys = entMan.System<SharedHandsSystem>();
+        var offerSys = entMan.System<OfferItemSystem>();
+
+        var map = await pair.CreateTestMap();
+        await pair.RunTicksSync(5);
+
+        EntityUid a = default, b = default, item = default;
+        HandsComponent? aHands = default;
+
+        await server.WaitPost(() =>
+        {
+            a = entMan.SpawnEntity("MobHuman", map.GridCoords);
+            b = entMan.SpawnEntity("MobHuman", map.GridCoords);
+            item = entMan.SpawnEntity("Crowbar", map.GridCoords);
+
+            aHands = entMan.GetComponent<HandsComponent>(a);
+            handsSys.TryPickup(a, item, aHands.ActiveHandId!);
+
+            var compA = entMan.GetComponent<OfferItemComponent>(a);
+            var compB = entMan.GetComponent<OfferItemComponent>(b);
+            offerSys.StartOffer(a, compA, item, aHands.ActiveHandId!);
+            offerSys.LinkOffer(a, compA, b, compB);
+
+            Assert.That(compB.Target, Is.EqualTo(a));
+
+            entMan.DeleteEntity(a);
+        });
+
+        await pair.RunTicksSync(5);
+
+        await server.WaitPost(() =>
+        {
+            var compB = entMan.GetComponent<OfferItemComponent>(b);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(compB.IsInReceiveMode, Is.False);
+                Assert.That(compB.Item, Is.Null);
+                Assert.That(compB.Target, Is.Null);
+            });
+
+            // Выжившая сторона должна сериализоваться чисто (регрессия: краш висячего EntityUid).
+            Assert.DoesNotThrow(() => entMan.GetComponentState(entMan.EventBus, compB, null, GameTick.Zero));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/_CorvaxGoob/OfferItem/OfferItemSystem.cs
+++ b/Content.Server/_CorvaxGoob/OfferItem/OfferItemSystem.cs
@@ -1,16 +1,13 @@
 using Content.Shared._CorvaxGoob.OfferItem;
 using Content.Shared.Alert;
-using Content.Shared.Hands.Components;
-using Content.Shared.Hands.EntitySystems;
 
 namespace Content.Server._CorvaxGoob.OfferItem;
 
 public sealed class OfferItemSystem : SharedOfferItemSystem
 {
-    [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly AlertsSystem _alertsSystem = default!;
 
-    private float _offerAcc = 0;
+    private float _offerAcc;
     private const float OfferAccMax = 3f;
 
     public override void Update(float frameTime)
@@ -22,31 +19,23 @@ public sealed class OfferItemSystem : SharedOfferItemSystem
         else
             return;
 
-        var query = EntityQueryEnumerator<OfferItemComponent, HandsComponent>();
-        while (query.MoveNext(out var uid, out var offerItem, out var hands))
+        var query = EntityQueryEnumerator<OfferItemComponent>();
+        while (query.MoveNext(out var uid, out var offerItem))
         {
-            if (_hands.GetActiveHand(uid) == null)
-                continue;
-
-            if (offerItem.Hand is not null && _hands.HandIsEmpty((uid, hands), offerItem.Hand))
-            {
-                if (offerItem.Target is not null)
-                {
-                    UnReceive(offerItem.Target.Value, offerItem: offerItem);
-                    offerItem.IsInOfferMode = false;
-                    Dirty(uid, offerItem);
-                }
-                else
-                    UnOffer(uid, offerItem);
-            }
-
-            if (!offerItem.IsInReceiveMode)
-            {
+            if (offerItem.IsInReceiveMode)
+                _alertsSystem.ShowAlert(uid, OfferAlert);
+            else
                 _alertsSystem.ClearAlert(uid, OfferAlert);
-                continue;
-            }
-
-            _alertsSystem.ShowAlert(uid, OfferAlert);
         }
     }
+
+    // Внутренние обёртки над переходами состояния для интеграционных тестов.
+    internal void StartOffer(EntityUid uid, OfferItemComponent comp, EntityUid item, string hand)
+        => base.StartOffer(uid, comp, item, hand);
+
+    internal void LinkOffer(EntityUid user, OfferItemComponent userComp, EntityUid target, OfferItemComponent targetComp)
+        => base.LinkOffer(user, userComp, target, targetComp);
+
+    internal void AcceptOffer(Entity<OfferItemComponent> ent)
+        => base.AcceptOffer(ent);
 }

--- a/Content.Shared/_CorvaxGoob/OfferItem/SharedOfferItemSystem.Interactions.cs
+++ b/Content.Shared/_CorvaxGoob/OfferItem/SharedOfferItemSystem.Interactions.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.ActionBlocker;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Hands.Components;
 using Content.Shared.Input;
 using Robust.Shared.Input.Binding;
@@ -12,7 +12,7 @@ public abstract partial class SharedOfferItemSystem
 
     private void InitializeInteractions()
     {
-        InitializeVerbMenu(); // offer-item-alternative-verb
+        InitializeVerbMenu();
 
         CommandBinds.Builder
             .Bind(ContentKeyFunctions.OfferItem, InputCmdHandler.FromDelegate(SetInOfferMode, handle: false, outsidePrediction: false))
@@ -43,11 +43,11 @@ public abstract partial class SharedOfferItemSystem
         if (!TryComp<HandsComponent>(uid, out var hands) || hands.ActiveHandId == null)
             return;
 
-        offerItem.Item = _hands.GetActiveItem(uid);
+        var item = _hands.GetActiveItem(uid);
 
         if (!offerItem.IsInOfferMode)
         {
-            if (offerItem.Item is null)
+            if (item is null)
             {
                 _popup.PopupEntity(Loc.GetString("offer-item-empty-hand"), uid, uid);
                 return;
@@ -55,22 +55,11 @@ public abstract partial class SharedOfferItemSystem
 
             if (offerItem.Hand is null || offerItem.Target is null)
             {
-                offerItem.IsInOfferMode = true;
-                offerItem.Hand = hands.ActiveHandId;
-
-                Dirty(uid, offerItem);
+                StartOffer(uid, offerItem, item.Value, hands.ActiveHandId);
                 return;
             }
         }
 
-        if (offerItem.Target is not null)
-        {
-            UnReceive(offerItem.Target.Value, offerItem: offerItem);
-            offerItem.IsInOfferMode = false;
-            Dirty(uid, offerItem);
-            return;
-        }
-
-        UnOffer(uid, offerItem);
+        ResetOffer(uid, offerItem);
     }
 }

--- a/Content.Shared/_CorvaxGoob/OfferItem/SharedOfferItemSystem.Verbs.cs
+++ b/Content.Shared/_CorvaxGoob/OfferItem/SharedOfferItemSystem.Verbs.cs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Verbs;
@@ -11,13 +9,13 @@ public abstract partial class SharedOfferItemSystem
 {
     private void InitializeVerbMenu()
     {
-        // Keep the context-menu entry separate from the keybind setup while sharing the same offer flow.
+        // Пункт контекстного меню отделён от настройки кейбинда, но использует тот же поток оффера.
         SubscribeLocalEvent<OfferItemComponent, GetVerbsEvent<InteractionVerb>>(OnGetOfferItemVerb);
     }
 
     private void OnGetOfferItemVerb(Entity<OfferItemComponent> ent, ref GetVerbsEvent<InteractionVerb> args)
     {
-        // Show the verb only for another valid character while the user is holding an active item.
+        // Показываем верб только для другого валидного персонажа, пока у пользователя активный предмет.
         if (!args.CanAccess ||
             args.Hands?.ActiveHandId is not { } hand ||
             args.Using is not { } used)
@@ -36,7 +34,7 @@ public abstract partial class SharedOfferItemSystem
         if (!CanOfferItem(user, target, item, handId))
             return;
 
-        // Copy values out of the ref event before creating the action; verb execution happens later.
+        // Копируем значения из ref-события до создания действия; верб выполняется позже.
         args.Verbs.Add(new InteractionVerb
         {
             Text = Loc.GetString("offer-item-verb"),
@@ -55,7 +53,7 @@ public abstract partial class SharedOfferItemSystem
         if (!_timing.IsFirstTimePredicted)
             return;
 
-        // Re-resolve components because hands, held item, or offer state may change while the menu is open.
+        // Повторно резолвим компоненты: руки, предмет или состояние оффера могли измениться, пока меню было открыто.
         if (!Resolve(user, ref user.Comp, false) ||
             !Resolve(target, ref target.Comp, false) ||
             !CanOfferItem(user, target, used, hand))
@@ -63,18 +61,13 @@ public abstract partial class SharedOfferItemSystem
             return;
         }
 
-        user.Comp.Item = used;
-        user.Comp.Hand = hand;
-        user.Comp.IsInOfferMode = true;
-        Dirty(user.Owner, user.Comp);
-
-        // Reuse the existing interact-using handler so popups, alerts, and acceptance stay identical.
-        var ev = new InteractUsingEvent(user.Owner, used, target.Owner, Transform(target.Owner).Coordinates);
-        SetInReceiveMode(target.Owner, target.Comp, ev);
+        // Тот же поток, что и у кейбинда: начинаем оффер, затем связываем обе стороны.
+        StartOffer(user.Owner, user.Comp, used, hand);
+        LinkOffer(user.Owner, user.Comp, target.Owner, target.Comp);
     }
 
-    // Shared guard for showing and executing the verb. The menu can stay open while state changes,
-    // so execution must pass the same checks again before starting an offer.
+    // Общая проверка предпосылок для показа и выполнения верба. Меню может оставаться открытым,
+    //пока состояние меняется, поэтому перед началом оффера те же проверки выполняются повторно.
     private bool CanOfferItem(
         Entity<OfferItemComponent?> user,
         Entity<OfferItemComponent?> target,

--- a/Content.Shared/_CorvaxGoob/OfferItem/SharedOfferItemSystem.cs
+++ b/Content.Shared/_CorvaxGoob/OfferItem/SharedOfferItemSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
+using Robust.Shared.Containers;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._CorvaxGoob.OfferItem;
@@ -16,13 +17,19 @@ public abstract partial class SharedOfferItemSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
+    private bool _acceptingOffer;
+
     [ValidatePrototypeId<AlertPrototype>]
     protected const string OfferAlert = "Offer";
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<OfferItemComponent, InteractUsingEvent>(SetInReceiveMode);
+        SubscribeLocalEvent<OfferItemComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<OfferItemComponent, MoveEvent>(OnMove);
+
+        SubscribeLocalEvent<OfferItemComponent, EntityTerminatingEvent>(OnOfferItemTerminating);
+
+        SubscribeLocalEvent<OfferItemComponent, EntRemovedFromContainerMessage>(OnHandContainerRemoved);
 
         InitializeInteractions();
 
@@ -39,83 +46,199 @@ public abstract partial class SharedOfferItemSystem : EntitySystem
 
         ev.Handled = true;
 
-        Receive(ent!);
+        AcceptOffer(ent);
     }
+
     /// <summary>
-    /// Accepting the offer and receive item
+    /// Вызывается при удалении любой стороны обмена. Очищает связанного партнёра,
+    /// чтобы «висячие» ссылки <see cref="EntityUid"/> не попали в PVS-сериализацию.
     /// </summary>
-    public void Receive(Entity<OfferItemComponent?> ent)
+    private void OnOfferItemTerminating(Entity<OfferItemComponent> ent, ref EntityTerminatingEvent args)
+    {
+        ResetOffer(ent, ent.Comp, showPopup: false);
+    }
+
+    /// <summary>
+    /// Вызывается при удалении предмета из контейнера руки. Если это был предлагаемый предмет,
+    /// оффер сбрасывается немедленно.
+    /// </summary>
+    private void OnHandContainerRemoved(EntityUid uid, OfferItemComponent comp, ref EntRemovedFromContainerMessage args)
+    {
+        if (args.Entity == EntityUid.Invalid)
+            return;
+
+        if (comp.Item != args.Entity)
+            return;
+
+        // Во время приёма подбор предмета тоже вынимает его из руки
+        ResetOffer(uid, comp, showPopup: !_acceptingOffer);
+    }
+
+    /// <summary>
+    /// Начинает новый оффер на указанной стороне: запоминает предлагаемый предмет и руку,
+    /// в которой он находится.
+    /// </summary>
+    protected void StartOffer(EntityUid uid, OfferItemComponent comp, EntityUid item, string hand)
+    {
+        comp.Item = item;
+        comp.Hand = hand;
+        comp.IsInOfferMode = true;
+        Dirty(uid, comp);
+    }
+
+    /// <summary>
+    /// Связывает предлагающего и получателя в активный обмен одним вызовом.
+    /// </summary>
+    protected void LinkOffer(EntityUid user, OfferItemComponent userComp, EntityUid target, OfferItemComponent targetComp)
+    {
+        targetComp.IsInReceiveMode = true;
+        targetComp.Target = user;
+        Dirty(target, targetComp);
+
+        userComp.Target = target;
+        userComp.IsInOfferMode = false;
+        Dirty(user, userComp);
+
+        if (userComp.Item is not { } item)
+            return;
+
+        _popup.PopupPredicted(Loc.GetString("offer-item-try-give",
+            ("item", Identity.Entity(item, EntityManager)),
+            ("target", Identity.Entity(target, EntityManager))), user, user);
+        _popup.PopupClient(Loc.GetString("offer-item-try-give-target",
+            ("user", Identity.Entity(user, EntityManager)),
+            ("item", Identity.Entity(item, EntityManager))), user, target);
+    }
+
+    /// <summary>
+    /// Сбрасывает состояние оффера для <paramref name="uid"/> и, если есть связь, для партнёра.
+    /// Это единственное место очистки полей компонента.
+    /// </summary>
+    protected void ResetOffer(EntityUid uid, OfferItemComponent comp, bool showPopup = true)
+    {
+        if (comp.Target is { Valid: true } target && TryComp<OfferItemComponent>(target, out var partner))
+        {
+            if (showPopup)
+                ShowCancelPopups(uid, comp);
+
+            partner.IsInOfferMode = false;
+            partner.IsInReceiveMode = false;
+            partner.Hand = null;
+            partner.Target = null;
+            partner.Item = null;
+            Dirty(target, partner);
+        }
+
+        comp.IsInOfferMode = false;
+        comp.IsInReceiveMode = false;
+        comp.Hand = null;
+        comp.Target = null;
+        comp.Item = null;
+        Dirty(uid, comp);
+    }
+
+    /// <summary>
+    /// Показывает попапы «не отдал предмет». Определяет, кто держит предмет, а кто получатель.
+    /// </summary>
+    private void ShowCancelPopups(EntityUid uid, OfferItemComponent comp)
     {
         if (!_timing.IsFirstTimePredicted)
             return;
 
-        if (!Resolve(ent, ref ent.Comp))
+        EntityUid holder;
+        EntityUid recipient;
+        EntityUid item;
+
+        if (comp.Item is { } selfItem)
+        {
+            holder = uid;
+            recipient = comp.Target is { Valid: true } t ? t : uid;
+            item = selfItem;
+        }
+        else if (comp.Target is { Valid: true } target && TryComp<OfferItemComponent>(target, out var partner) && partner.Item is { } partnerItem)
+        {
+            holder = target;
+            recipient = uid;
+            item = partnerItem;
+        }
+        else
+        {
+            return;
+        }
+
+        _popup.PopupClient(Loc.GetString("offer-item-no-give",
+            ("item", Identity.Entity(item, EntityManager)),
+            ("target", Identity.Entity(recipient, EntityManager))), holder, holder);
+        _popup.PopupEntity(Loc.GetString("offer-item-no-give-target",
+            ("user", Identity.Entity(holder, EntityManager)),
+            ("item", Identity.Entity(item, EntityManager))), holder, recipient);
+    }
+
+    /// <summary>
+    /// Принимает оффер и подбирает предмет. При успехе обе стороны сбрасываются без попапов
+    /// (передача уже состоялась, показывать «не отдал» не нужно).
+    /// </summary>
+    protected void AcceptOffer(Entity<OfferItemComponent> ent)
+    {
+        if (!_timing.IsFirstTimePredicted)
             return;
 
-        if (!TryComp<OfferItemComponent>(ent.Comp.Target, out var offerItem))
+        if (ent.Comp.Target is not { Valid: true } target)
             return;
 
-        if (offerItem.Hand is null)
+        if (!TryComp<OfferItemComponent>(target, out var offerItem))
             return;
 
-        if (ent.Comp.Target is null)
+        if (offerItem.Hand is null || offerItem.Item is not { } item)
             return;
 
         if (!TryComp<HandsComponent>(ent, out var hands))
             return;
 
-        if (offerItem.Item is not null)
+        bool pickedUp;
+        _acceptingOffer = true;
+        try
         {
-            if (!_hands.TryPickup(ent, offerItem.Item.Value, handsComp: hands))
-            {
-                _popup.PopupClient(Loc.GetString("offer-item-full-hand"), ent, ent);
-                return;
-            }
-
-            _popup.PopupClient(Loc.GetString("offer-item-give",
-                ("item", Identity.Entity(offerItem.Item.Value, EntityManager)),
-                ("target", Identity.Entity(ent, EntityManager))), ent.Comp.Target.Value, ent.Comp.Target.Value);
-
-            _popup.PopupPredicted(Loc.GetString("offer-item-give-other",
-                    ("user", Identity.Entity(ent.Comp.Target.Value, EntityManager)),
-                    ("item", Identity.Entity(offerItem.Item.Value, EntityManager)),
-                    ("target", Identity.Entity(ent, EntityManager))),
-                ent.Comp.Target.Value,
-                ent);
+            pickedUp = _hands.TryPickup(ent, item, handsComp: hands);
+        }
+        finally
+        {
+            _acceptingOffer = false;
         }
 
-        offerItem.Item = null;
-        Dirty(ent.Comp.Target.Value, offerItem);
-        UnReceive(ent, ent, offerItem);
+        if (!pickedUp)
+        {
+            _popup.PopupClient(Loc.GetString("offer-item-full-hand"), ent, ent);
+            return;
+        }
+
+        _popup.PopupClient(Loc.GetString("offer-item-give",
+            ("item", Identity.Entity(item, EntityManager)),
+            ("target", Identity.Entity(ent, EntityManager))), target, target);
+
+        _popup.PopupPredicted(Loc.GetString("offer-item-give-other",
+                ("user", Identity.Entity(target, EntityManager)),
+                ("item", Identity.Entity(item, EntityManager)),
+                ("target", Identity.Entity(ent, EntityManager))),
+            target,
+            ent);
+
+        // Передача состоялась - сбрасываем обе стороны.
+        ResetOffer(ent, ent.Comp, showPopup: false);
     }
 
-    private void SetInReceiveMode(EntityUid uid, OfferItemComponent component, InteractUsingEvent args)
+    private void OnInteractUsing(EntityUid uid, OfferItemComponent component, ref InteractUsingEvent args)
     {
-        if (!TryComp<OfferItemComponent>(args.User, out var offerItem))
+        if (!TryComp<OfferItemComponent>(args.User, out var userComp))
             return;
 
-        if (args.User == uid || component.IsInReceiveMode || !offerItem.IsInOfferMode || offerItem.IsInReceiveMode && offerItem.Target != uid)
+        if (args.User == uid || component.IsInReceiveMode || !userComp.IsInOfferMode ||
+            userComp.IsInReceiveMode && userComp.Target != uid)
+        {
             return;
+        }
 
-        component.IsInReceiveMode = true;
-        component.Target = args.User;
-
-        Dirty(uid, component);
-
-        offerItem.Target = uid;
-        offerItem.IsInOfferMode = false;
-
-        Dirty(args.User, offerItem);
-
-        if (offerItem.Item == null)
-            return;
-
-        _popup.PopupPredicted(Loc.GetString("offer-item-try-give",
-            ("item", Identity.Entity(offerItem.Item.Value, EntityManager)),
-            ("target", Identity.Entity(uid, EntityManager))), component.Target.Value, component.Target.Value);
-        _popup.PopupClient(Loc.GetString("offer-item-try-give-target",
-            ("user", Identity.Entity(component.Target.Value, EntityManager)),
-            ("item", Identity.Entity(offerItem.Item.Value, EntityManager))), component.Target.Value, uid);
+        LinkOffer(args.User, userComp, uid, component);
 
         args.Handled = true;
     }
@@ -130,104 +253,11 @@ public abstract partial class SharedOfferItemSystem : EntitySystem
         if (_transform.InRange(args.NewPosition, targetCoords, component.MaxOfferDistance))
             return;
 
-        UnOffer(uid, component);
+        ResetOffer(uid, component);
     }
 
     /// <summary>
-    /// Resets the <see cref="OfferItemComponent"/> of the user and the target
-    /// </summary>
-    protected void UnOffer(EntityUid uid, OfferItemComponent component)
-    {
-        if (!TryComp<HandsComponent>(uid, out var hands) || hands.ActiveHandId is null)
-            return;
-
-        if (component.Target is { Valid: true } && TryComp<OfferItemComponent>(component.Target, out var offerItem))
-        {
-            if (component.Item is not null)
-            {
-                if (_timing.IsFirstTimePredicted)
-                {
-                    _popup.PopupClient(Loc.GetString("offer-item-no-give",
-                        ("item", Identity.Entity(component.Item.Value, EntityManager)),
-                        ("target", Identity.Entity(component.Target.Value, EntityManager))), uid, uid);
-                    _popup.PopupEntity(Loc.GetString("offer-item-no-give-target",
-                        ("user", Identity.Entity(uid, EntityManager)),
-                        ("item", Identity.Entity(component.Item.Value, EntityManager))), uid, component.Target.Value);
-                }
-
-            }
-            else if (offerItem.Item is not null)
-            {
-                if (_timing.IsFirstTimePredicted)
-                {
-                    _popup.PopupClient(Loc.GetString("offer-item-no-give",
-                        ("item", Identity.Entity(offerItem.Item.Value, EntityManager)),
-                        ("target", Identity.Entity(uid, EntityManager))), component.Target.Value, component.Target.Value);
-                    _popup.PopupEntity(Loc.GetString("offer-item-no-give-target",
-                        ("user", Identity.Entity(component.Target.Value, EntityManager)),
-                        ("item", Identity.Entity(offerItem.Item.Value, EntityManager))), component.Target.Value, uid);
-                }
-            }
-
-            offerItem.IsInOfferMode = false;
-            offerItem.IsInReceiveMode = false;
-            offerItem.Hand = null;
-            offerItem.Target = null;
-            offerItem.Item = null;
-
-            Dirty(component.Target.Value, offerItem);
-        }
-
-        component.IsInOfferMode = false;
-        component.IsInReceiveMode = false;
-        component.Hand = null;
-        component.Target = null;
-        component.Item = null;
-
-        Dirty(uid, component);
-    }
-
-
-    /// <summary>
-    /// Cancels the transfer of the item
-    /// </summary>
-    protected void UnReceive(EntityUid uid, OfferItemComponent? component = null, OfferItemComponent? offerItem = null)
-    {
-        if (component is null && !TryComp(uid, out component))
-            return;
-
-        if (offerItem is null && !TryComp(component.Target, out offerItem))
-            return;
-
-        if (!TryComp<HandsComponent>(uid, out var hands) || hands.ActiveHandId is null ||
-            component.Target is null)
-            return;
-
-        if (offerItem.Item is not null && _timing.IsFirstTimePredicted)
-        {
-            _popup.PopupClient(Loc.GetString("offer-item-no-give",
-                ("item", Identity.Entity(offerItem.Item.Value, EntityManager)),
-                ("target", Identity.Entity(uid, EntityManager))), component.Target.Value, component.Target.Value);
-            _popup.PopupEntity(Loc.GetString("offer-item-no-give-target",
-                ("user", Identity.Entity(component.Target.Value, EntityManager)),
-                ("item", Identity.Entity(offerItem.Item.Value, EntityManager))), component.Target.Value, uid);
-        }
-
-        if (!offerItem.IsInReceiveMode)
-        {
-            offerItem.Target = null;
-            component.Target = null;
-        }
-
-        offerItem.Item = null;
-        offerItem.Hand = null;
-        component.IsInReceiveMode = false;
-
-        Dirty(uid, component);
-    }
-
-    /// <summary>
-    /// Returns true if <see cref="OfferItemComponent.IsInOfferMode"/> = true
+    /// Возвращает true, если <see cref="OfferItemComponent.IsInOfferMode"/> = true
     /// </summary>
     protected bool IsInOfferMode(EntityUid? entity, OfferItemComponent? component = null)
     {


### PR DESCRIPTION
## Описание PR
Обновил систему передачи в руку, т.к. она несколько устарела и начала создавать проблемы.
(Далее скучный текст не читайте его)
Убрал излишнюю симметричную синхронизацию - это спорное решение, которые приводило к постоянным ошибкам на бекенде, а потом увлёкся, т.к. те ошибки не решаются простым патчем, потом по приколу сгенерил тест. 
Из злободневного:
- Сброс состояния безусловный и больше не зависит от наличия рук - это чинит зависание при потере рук
- При удалении любой стороны обмена или предмета из руки состояние сбрасывается мгновенно
- Устранено дублирование логики

Главное - устранён краш при сериализации из-за висячей ссылки на удалённую сущность - теперь обе стороны гарантированно очищаются до.